### PR TITLE
Privatize funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Go client for [Linode REST v4 API](https://developers.linode.com/v4/introduction
 
 ## Installation
 
-```
-$ go get -u github.com/chiefy/linodego
+```sh
+go get -u github.com/chiefy/linodego
 ```
 
 ## API Support
@@ -63,6 +63,7 @@ func main() {
 ```
 
 ### Pagination
+
 #### Auto-Pagination Requests
 
 ```go
@@ -89,6 +90,7 @@ stackscripts, err := linodego.ListStackscripts(opts)
 ```
 
 ### Error Handling
+
 #### Getting Single Entities
 
 ```go

--- a/README.md
+++ b/README.md
@@ -124,9 +124,7 @@ linodes, err := linodego.ListLinodes(NewListOptions(9999, ""))
 When performing a `POST` or `PUT` request, multiple field related errors will be returned as a single error, currently like:
 
 ```go
-// err.Error() == "[400] [field1] the problem reported by the API
-// [field2] the problem reported by the API
-// [field3] the problem reported by the API"
+// err.Error() == "[400] [field1] foo problem; [field2] bar problem; [field3] baz problem"
 ```
 
 ## Discussion / Help

--- a/account_events.go
+++ b/account_events.go
@@ -40,8 +40,8 @@ type EventsPagedResponse struct {
 	Data []*Event
 }
 
-// Endpoint gets the endpoint URL for Event
-func (EventsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Event
+func (EventsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Events.Endpoint()
 	if err != nil {
 		panic(err)
@@ -49,22 +49,22 @@ func (EventsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// EndpointWithID gets the endpoint URL for a specific Event
-func (EventsPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.Events.EndpointWithID(id)
+// endpointWithID gets the endpoint URL for a specific Event
+func (EventsPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.Events.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends Events when processing paginated Event responses
-func (resp *EventsPagedResponse) AppendData(r *EventsPagedResponse) {
+// appendData appends Events when processing paginated Event responses
+func (resp *EventsPagedResponse) appendData(r *EventsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Events
-func (EventsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Events
+func (EventsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(EventsPagedResponse{})
 }
 
@@ -73,7 +73,7 @@ func (EventsPagedResponse) SetResult(r *resty.Request) {
 // of the associated user.
 func (c *Client) ListEvents(opts *ListOptions) ([]*Event, error) {
 	response := EventsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/account_invoices.go
+++ b/account_invoices.go
@@ -37,8 +37,8 @@ type InvoicesPagedResponse struct {
 	Data []*Invoice
 }
 
-// Endpoint gets the endpoint URL for Invoice
-func (InvoicesPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Invoice
+func (InvoicesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Invoices.Endpoint()
 	if err != nil {
 		panic(err)
@@ -46,20 +46,20 @@ func (InvoicesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Invoices when processing paginated Invoice responses
-func (resp *InvoicesPagedResponse) AppendData(r *InvoicesPagedResponse) {
+// appendData appends Invoices when processing paginated Invoice responses
+func (resp *InvoicesPagedResponse) appendData(r *InvoicesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Invoice
-func (InvoicesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Invoice
+func (InvoicesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(InvoicesPagedResponse{})
 }
 
 // ListInvoices gets a paginated list of Invoices against the Account
 func (c *Client) ListInvoices(opts *ListOptions) ([]*Invoice, error) {
 	response := InvoicesPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}
@@ -103,29 +103,29 @@ type InvoiceItemsPagedResponse struct {
 	Data []*InvoiceItem
 }
 
-// EndpointWithID gets the endpoint URL for InvoiceItems associated with a specific Invoice
-func (InvoiceItemsPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.InvoiceItems.EndpointWithID(id)
+// endpointWithID gets the endpoint URL for InvoiceItems associated with a specific Invoice
+func (InvoiceItemsPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.InvoiceItems.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends InvoiceItems when processing paginated Invoice Item responses
-func (resp *InvoiceItemsPagedResponse) AppendData(r *InvoiceItemsPagedResponse) {
+// appendData appends InvoiceItems when processing paginated Invoice Item responses
+func (resp *InvoiceItemsPagedResponse) appendData(r *InvoiceItemsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of InvoiceItems
-func (InvoiceItemsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of InvoiceItems
+func (InvoiceItemsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(InvoiceItemsPagedResponse{})
 }
 
 // ListInvoiceItems gets the invoice items associated with a specific Invoice
 func (c *Client) ListInvoiceItems(id int, opts *ListOptions) ([]*InvoiceItem, error) {
 	response := InvoiceItemsPagedResponse{}
-	err := c.ListHelperWithID(&response, id, opts)
+	err := c.listHelperWithID(&response, id, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/account_notifications.go
+++ b/account_notifications.go
@@ -34,8 +34,8 @@ type NotificationsPagedResponse struct {
 	Data []*Notification
 }
 
-// Endpoint gets the endpoint URL for Notification
-func (NotificationsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Notification
+func (NotificationsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Notifications.Endpoint()
 	if err != nil {
 		panic(err)
@@ -43,13 +43,13 @@ func (NotificationsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Notifications when processing paginated Notification responses
-func (resp *NotificationsPagedResponse) AppendData(r *NotificationsPagedResponse) {
+// appendData appends Notifications when processing paginated Notification responses
+func (resp *NotificationsPagedResponse) appendData(r *NotificationsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Notifications
-func (NotificationsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Notifications
+func (NotificationsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(NotificationsPagedResponse{})
 }
 
@@ -60,7 +60,7 @@ func (NotificationsPagedResponse) SetResult(r *resty.Request) {
 // to the Ticket will dismiss the Notification.
 func (c *Client) ListNotifications(opts *ListOptions) ([]*Notification, error) {
 	response := NotificationsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/domain_records.go
+++ b/domain_records.go
@@ -27,29 +27,29 @@ type DomainRecordsPagedResponse struct {
 	Data []*DomainRecord
 }
 
-// Endpoint gets the endpoint URL for InstanceConfig
-func (DomainRecordsPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.DomainRecords.EndpointWithID(id)
+// endpoint gets the endpoint URL for InstanceConfig
+func (DomainRecordsPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.DomainRecords.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends DomainRecords when processing paginated DomainRecord responses
-func (resp *DomainRecordsPagedResponse) AppendData(r *DomainRecordsPagedResponse) {
+// appendData appends DomainRecords when processing paginated DomainRecord responses
+func (resp *DomainRecordsPagedResponse) appendData(r *DomainRecordsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of DomainRecord
-func (DomainRecordsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of DomainRecord
+func (DomainRecordsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(DomainRecordsPagedResponse{})
 }
 
 // ListDomainRecords lists DomainRecords
 func (c *Client) ListDomainRecords(opts *ListOptions) ([]*DomainRecord, error) {
 	response := DomainRecordsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/domains.go
+++ b/domains.go
@@ -21,8 +21,8 @@ type DomainsPagedResponse struct {
 	Data []*Domain
 }
 
-// Endpoint gets the endpoint URL for Domain
-func (DomainsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Domain
+func (DomainsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Domains.Endpoint()
 	if err != nil {
 		panic(err)
@@ -30,20 +30,20 @@ func (DomainsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Domains when processing paginated Domain responses
-func (resp *DomainsPagedResponse) AppendData(r *DomainsPagedResponse) {
+// appendData appends Domains when processing paginated Domain responses
+func (resp *DomainsPagedResponse) appendData(r *DomainsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Domain
-func (DomainsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Domain
+func (DomainsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(DomainsPagedResponse{})
 }
 
 // ListDomains lists Domains
 func (c *Client) ListDomains(opts *ListOptions) ([]*Domain, error) {
 	response := DomainsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/errors.go
+++ b/errors.go
@@ -64,7 +64,7 @@ func (e APIError) Error() string {
 	for _, msg := range e.Errors {
 		x = append(x, msg.Error())
 	}
-	return strings.Join(x, "\n")
+	return strings.Join(x, "; ")
 }
 
 func (g Error) Error() string {

--- a/images.go
+++ b/images.go
@@ -37,7 +37,7 @@ type ImagesPagedResponse struct {
 	Data []*Image
 }
 
-func (ImagesPagedResponse) Endpoint(c *Client) string {
+func (ImagesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Images.Endpoint()
 	if err != nil {
 		panic(err)
@@ -45,18 +45,18 @@ func (ImagesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-func (resp *ImagesPagedResponse) AppendData(r *ImagesPagedResponse) {
+func (resp *ImagesPagedResponse) appendData(r *ImagesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-func (ImagesPagedResponse) SetResult(r *resty.Request) {
+func (ImagesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(ImagesPagedResponse{})
 }
 
 // ListImages lists Images
 func (c *Client) ListImages(opts *ListOptions) ([]*Image, error) {
 	response := ImagesPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/instance_configs.go
+++ b/instance_configs.go
@@ -104,29 +104,29 @@ func (i InstanceConfig) GetUpdateOptions() InstanceConfigUpdateOptions {
 	}
 }
 
-// EndpointWithID gets the endpoint URL for InstanceConfigs of a given Instance
-func (InstanceConfigsPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.InstanceConfigs.EndpointWithID(id)
+// endpointWithID gets the endpoint URL for InstanceConfigs of a given Instance
+func (InstanceConfigsPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.InstanceConfigs.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends InstanceConfigs when processing paginated InstanceConfig responses
-func (resp *InstanceConfigsPagedResponse) AppendData(r *InstanceConfigsPagedResponse) {
+// appendData appends InstanceConfigs when processing paginated InstanceConfig responses
+func (resp *InstanceConfigsPagedResponse) appendData(r *InstanceConfigsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of InstanceConfig
-func (InstanceConfigsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of InstanceConfig
+func (InstanceConfigsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(InstanceConfigsPagedResponse{})
 }
 
 // ListInstanceConfigs lists InstanceConfigs
 func (c *Client) ListInstanceConfigs(linodeID int, opts *ListOptions) ([]*InstanceConfig, error) {
 	response := InstanceConfigsPagedResponse{}
-	err := c.ListHelperWithID(&response, linodeID, opts)
+	err := c.listHelperWithID(&response, linodeID, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}
@@ -145,7 +145,7 @@ func (v *InstanceConfig) fixDates() *InstanceConfig {
 
 // GetInstanceConfig gets the template with the provided ID
 func (c *Client) GetInstanceConfig(linodeID int, configID int) (*InstanceConfig, error) {
-	e, err := c.InstanceConfigs.EndpointWithID(linodeID)
+	e, err := c.InstanceConfigs.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (c *Client) GetInstanceConfig(linodeID int, configID int) (*InstanceConfig,
 // CreateInstanceConfig creates a new InstanceConfig for the given Instance
 func (c *Client) CreateInstanceConfig(linodeID int, createOpts InstanceConfigCreateOptions) (*InstanceConfig, error) {
 	var body string
-	e, err := c.InstanceConfigs.EndpointWithID(linodeID)
+	e, err := c.InstanceConfigs.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (c *Client) CreateInstanceConfig(linodeID int, createOpts InstanceConfigCre
 // UpdateInstanceConfig update an InstanceConfig for the given Instance
 func (c *Client) UpdateInstanceConfig(linodeID int, configID int, updateOpts InstanceConfigUpdateOptions) (*InstanceConfig, error) {
 	var body string
-	e, err := c.InstanceConfigs.EndpointWithID(linodeID)
+	e, err := c.InstanceConfigs.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (c *Client) RenameInstanceConfig(linodeID int, configID int, label string) 
 
 // DeleteInstanceConfig deletes a Linode InstanceConfig
 func (c *Client) DeleteInstanceConfig(id int) error {
-	e, err := c.InstanceConfigs.EndpointWithID(id)
+	e, err := c.InstanceConfigs.endpointWithID(id)
 	if err != nil {
 		return err
 	}

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -49,29 +49,29 @@ type InstanceDiskUpdateOptions struct {
 	ReadOnly bool   `json:"read_only,omitempty"`
 }
 
-// EndpointWithID gets the endpoint URL for InstanceDisks of a given Instance
-func (InstanceDisksPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.InstanceDisks.EndpointWithID(id)
+// endpointWithID gets the endpoint URL for InstanceDisks of a given Instance
+func (InstanceDisksPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.InstanceDisks.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends InstanceDisks when processing paginated InstanceDisk responses
-func (resp *InstanceDisksPagedResponse) AppendData(r *InstanceDisksPagedResponse) {
+// appendData appends InstanceDisks when processing paginated InstanceDisk responses
+func (resp *InstanceDisksPagedResponse) appendData(r *InstanceDisksPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of InstanceDisk
-func (InstanceDisksPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of InstanceDisk
+func (InstanceDisksPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(InstanceDisksPagedResponse{})
 }
 
 // ListInstanceDisks lists InstanceDisks
 func (c *Client) ListInstanceDisks(linodeID int, opts *ListOptions) ([]*InstanceDisk, error) {
 	response := InstanceDisksPagedResponse{}
-	err := c.ListHelperWithID(&response, linodeID, opts)
+	err := c.listHelperWithID(&response, linodeID, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}
@@ -90,7 +90,7 @@ func (v *InstanceDisk) fixDates() *InstanceDisk {
 
 // GetInstanceDisk gets the template with the provided ID
 func (c *Client) GetInstanceDisk(linodeID int, configID int) (*InstanceDisk, error) {
-	e, err := c.InstanceDisks.EndpointWithID(linodeID)
+	e, err := c.InstanceDisks.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (c *Client) GetInstanceDisk(linodeID int, configID int) (*InstanceDisk, err
 // CreateInstanceDisk creates a new InstanceDisk for the given Instance
 func (c *Client) CreateInstanceDisk(linodeID int, createOpts InstanceDiskCreateOptions) (*InstanceDisk, error) {
 	var body string
-	e, err := c.InstanceDisks.EndpointWithID(linodeID)
+	e, err := c.InstanceDisks.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (c *Client) CreateInstanceDisk(linodeID int, createOpts InstanceDiskCreateO
 // UpdateInstanceDisk creates a new InstanceDisk for the given Instance
 func (c *Client) UpdateInstanceDisk(linodeID int, diskID int, updateOpts InstanceDiskUpdateOptions) (*InstanceDisk, error) {
 	var body string
-	e, err := c.InstanceDisks.EndpointWithID(linodeID)
+	e, err := c.InstanceDisks.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (c *Client) RenameInstanceDisk(linodeID int, diskID int, label string) (*In
 // ResizeInstanceDisk resizes the size of the Instance disk
 func (c *Client) ResizeInstanceDisk(linodeID int, diskID int, size int) (*InstanceDisk, error) {
 	var body string
-	e, err := c.InstanceDisks.EndpointWithID(linodeID)
+	e, err := c.InstanceDisks.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (c *Client) ResizeInstanceDisk(linodeID int, diskID int, size int) (*Instan
 
 // DeleteInstanceDisk deletes a Linode InstanceDisk
 func (c *Client) DeleteInstanceDisk(id int) error {
-	e, err := c.InstanceDisks.EndpointWithID(id)
+	e, err := c.InstanceDisks.endpointWithID(id)
 	if err != nil {
 		return err
 	}

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -41,7 +41,7 @@ type IPv6Range struct {
 
 // GetInstanceIPAddresses gets the IPAddresses for a Linode instance
 func (c *Client) GetInstanceIPAddresses(linodeID int) (*InstanceIPAddressResponse, error) {
-	e, err := c.InstanceIPs.EndpointWithID(linodeID)
+	e, err := c.InstanceIPs.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (c *Client) GetInstanceIPAddresses(linodeID int) (*InstanceIPAddressRespons
 
 // GetInstanceIPAddress gets the IPAddress for a Linode instance matching a supplied IP address
 func (c *Client) GetInstanceIPAddress(linodeID int, ipaddress string) (*InstanceIP, error) {
-	e, err := c.InstanceIPs.EndpointWithID(linodeID)
+	e, err := c.InstanceIPs.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (c *Client) GetInstanceIPAddress(linodeID int, ipaddress string) (*Instance
 // AddInstanceIPAddress adds a public or private IP to a Linode instance
 func (c *Client) AddInstanceIPAddress(linodeID int, public bool) (*InstanceIP, error) {
 	var body string
-	e, err := c.InstanceIPs.EndpointWithID(linodeID)
+	e, err := c.InstanceIPs.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}

--- a/instance_snapshots.go
+++ b/instance_snapshots.go
@@ -43,29 +43,29 @@ type InstanceSnapshotsPagedResponse struct {
 	Data []*InstanceSnapshot
 }
 
-// Endpoint gets the endpoint URL for InstanceSnapshot
-func (InstanceSnapshotsPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.InstanceSnapshots.EndpointWithID(id)
+// endpoint gets the endpoint URL for InstanceSnapshot
+func (InstanceSnapshotsPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.InstanceSnapshots.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends InstanceSnapshots when processing paginated InstanceSnapshot responses
-func (resp *InstanceSnapshotsPagedResponse) AppendData(r *InstanceSnapshotsPagedResponse) {
+// appendData appends InstanceSnapshots when processing paginated InstanceSnapshot responses
+func (resp *InstanceSnapshotsPagedResponse) appendData(r *InstanceSnapshotsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of InstanceSnapshot
-func (InstanceSnapshotsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of InstanceSnapshot
+func (InstanceSnapshotsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(InstanceSnapshotsPagedResponse{})
 }
 
 // ListInstanceSnapshots lists InstanceSnapshots
 func (c *Client) ListInstanceSnapshots(linodeID int, opts *ListOptions) ([]*InstanceSnapshot, error) {
 	response := InstanceSnapshotsPagedResponse{}
-	err := c.ListHelperWithID(&response, linodeID, opts)
+	err := c.listHelperWithID(&response, linodeID, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}
@@ -77,7 +77,7 @@ func (c *Client) ListInstanceSnapshots(linodeID int, opts *ListOptions) ([]*Inst
 
 // GetInstanceSnapshot gets the snapshot with the provided ID
 func (c *Client) GetInstanceSnapshot(linodeID int, snapshotID int) (*InstanceSnapshot, error) {
-	e, err := c.InstanceSnapshots.EndpointWithID(linodeID)
+	e, err := c.InstanceSnapshots.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}

--- a/instance_volumes.go
+++ b/instance_volumes.go
@@ -12,29 +12,29 @@ type InstanceVolumesPagedResponse struct {
 	Data []*Volume
 }
 
-// Endpoint gets the endpoint URL for InstanceVolume
-func (InstanceVolumesPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.InstanceVolumes.EndpointWithID(id)
+// endpoint gets the endpoint URL for InstanceVolume
+func (InstanceVolumesPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.InstanceVolumes.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends InstanceVolumes when processing paginated InstanceVolume responses
-func (resp *InstanceVolumesPagedResponse) AppendData(r *InstanceVolumesPagedResponse) {
+// appendData appends InstanceVolumes when processing paginated InstanceVolume responses
+func (resp *InstanceVolumesPagedResponse) appendData(r *InstanceVolumesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of InstanceVolume
-func (InstanceVolumesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of InstanceVolume
+func (InstanceVolumesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(InstanceVolumesPagedResponse{})
 }
 
 // ListInstanceVolumes lists InstanceVolumes
 func (c *Client) ListInstanceVolumes(linodeID int, opts *ListOptions) ([]*Volume, error) {
 	response := InstanceVolumesPagedResponse{}
-	err := c.ListHelperWithID(&response, linodeID, opts)
+	err := c.listHelperWithID(&response, linodeID, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}
@@ -46,7 +46,7 @@ func (c *Client) ListInstanceVolumes(linodeID int, opts *ListOptions) ([]*Volume
 
 // GetInstanceVolume gets the snapshot with the provided ID
 func (c *Client) GetInstanceVolume(linodeID int, snapshotID int) (*Volume, error) {
-	e, err := c.InstanceVolumes.EndpointWithID(linodeID)
+	e, err := c.InstanceVolumes.endpointWithID(linodeID)
 	if err != nil {
 		return nil, err
 	}

--- a/instances.go
+++ b/instances.go
@@ -110,8 +110,8 @@ type InstancesPagedResponse struct {
 	Data []*Instance
 }
 
-// Endpoint gets the endpoint URL for Instance
-func (InstancesPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Instance
+func (InstancesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Instances.Endpoint()
 	if err != nil {
 		panic(err)
@@ -119,13 +119,13 @@ func (InstancesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Instances when processing paginated Instance responses
-func (resp *InstancesPagedResponse) AppendData(r *InstancesPagedResponse) {
+// appendData appends Instances when processing paginated Instance responses
+func (resp *InstancesPagedResponse) appendData(r *InstancesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Instance
-func (InstancesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Instance
+func (InstancesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(InstancesPagedResponse{})
 }
 

--- a/kernels.go
+++ b/kernels.go
@@ -26,14 +26,14 @@ type LinodeKernelsPagedResponse struct {
 // ListKernels lists linode kernels
 func (c *Client) ListKernels(opts *ListOptions) ([]*LinodeKernel, error) {
 	response := LinodeKernelsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}
 	return response.Data, nil
 }
 
-func (LinodeKernelsPagedResponse) Endpoint(c *Client) string {
+func (LinodeKernelsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Kernels.Endpoint()
 	if err != nil {
 		panic(err)
@@ -41,11 +41,11 @@ func (LinodeKernelsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-func (resp *LinodeKernelsPagedResponse) AppendData(r *LinodeKernelsPagedResponse) {
+func (resp *LinodeKernelsPagedResponse) appendData(r *LinodeKernelsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-func (LinodeKernelsPagedResponse) SetResult(r *resty.Request) {
+func (LinodeKernelsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(LinodeKernelsPagedResponse{})
 }
 

--- a/kernels.go
+++ b/kernels.go
@@ -19,7 +19,7 @@ type LinodeKernel struct {
 
 // LinodeKernelsPagedResponse represents a linode kernels API response for listing
 type LinodeKernelsPagedResponse struct {
-	*PagedResponse
+	*PageOptions
 	Data []*LinodeKernel
 }
 

--- a/longview.go
+++ b/longview.go
@@ -19,8 +19,8 @@ type LongviewClientsPagedResponse struct {
 	Data []*LongviewClient
 }
 
-// Endpoint gets the endpoint URL for LongviewClient
-func (LongviewClientsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for LongviewClient
+func (LongviewClientsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.LongviewClients.Endpoint()
 	if err != nil {
 		panic(err)
@@ -28,20 +28,20 @@ func (LongviewClientsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends LongviewClients when processing paginated LongviewClient responses
-func (resp *LongviewClientsPagedResponse) AppendData(r *LongviewClientsPagedResponse) {
+// appendData appends LongviewClients when processing paginated LongviewClient responses
+func (resp *LongviewClientsPagedResponse) appendData(r *LongviewClientsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of LongviewClient
-func (LongviewClientsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of LongviewClient
+func (LongviewClientsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(LongviewClientsPagedResponse{})
 }
 
 // ListLongviewClients lists LongviewClients
 func (c *Client) ListLongviewClients(opts *ListOptions) ([]*LongviewClient, error) {
 	response := LongviewClientsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/longview_subscriptions.go
+++ b/longview_subscriptions.go
@@ -22,8 +22,8 @@ type LongviewSubscriptionsPagedResponse struct {
 	Data []*LongviewSubscription
 }
 
-// Endpoint gets the endpoint URL for LongviewSubscription
-func (LongviewSubscriptionsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for LongviewSubscription
+func (LongviewSubscriptionsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.LongviewSubscriptions.Endpoint()
 	if err != nil {
 		panic(err)
@@ -31,20 +31,20 @@ func (LongviewSubscriptionsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends LongviewSubscriptions when processing paginated LongviewSubscription responses
-func (resp *LongviewSubscriptionsPagedResponse) AppendData(r *LongviewSubscriptionsPagedResponse) {
+// appendData appends LongviewSubscriptions when processing paginated LongviewSubscription responses
+func (resp *LongviewSubscriptionsPagedResponse) appendData(r *LongviewSubscriptionsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of LongviewSubscription
-func (LongviewSubscriptionsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of LongviewSubscription
+func (LongviewSubscriptionsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(LongviewSubscriptionsPagedResponse{})
 }
 
 // ListLongviewSubscriptions lists LongviewSubscriptions
 func (c *Client) ListLongviewSubscriptions(opts *ListOptions) ([]*LongviewSubscription, error) {
 	response := LongviewSubscriptionsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/network_ips.go
+++ b/network_ips.go
@@ -12,8 +12,8 @@ type IPAddressesPagedResponse struct {
 	Data []*InstanceIP
 }
 
-// Endpoint gets the endpoint URL for IPAddress
-func (IPAddressesPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for IPAddress
+func (IPAddressesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.IPAddresses.Endpoint()
 	if err != nil {
 		panic(err)
@@ -21,20 +21,20 @@ func (IPAddressesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends IPAddresses when processing paginated InstanceIPAddress responses
-func (resp *IPAddressesPagedResponse) AppendData(r *IPAddressesPagedResponse) {
+// appendData appends IPAddresses when processing paginated InstanceIPAddress responses
+func (resp *IPAddressesPagedResponse) appendData(r *IPAddressesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of IPAddress
-func (IPAddressesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of IPAddress
+func (IPAddressesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(IPAddressesPagedResponse{})
 }
 
 // ListIPAddresses lists IPAddresses
 func (c *Client) ListIPAddresses(opts *ListOptions) ([]*InstanceIP, error) {
 	response := IPAddressesPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/network_pools.go
+++ b/network_pools.go
@@ -12,8 +12,8 @@ type IPv6PoolsPagedResponse struct {
 	Data []*IPv6Range
 }
 
-// Endpoint gets the endpoint URL for IPv6Pool
-func (IPv6PoolsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for IPv6Pool
+func (IPv6PoolsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.IPv6Pools.Endpoint()
 	if err != nil {
 		panic(err)
@@ -21,20 +21,20 @@ func (IPv6PoolsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends IPv6Pools when processing paginated IPv6Pool responses
-func (resp *IPv6PoolsPagedResponse) AppendData(r *IPv6PoolsPagedResponse) {
+// appendData appends IPv6Pools when processing paginated IPv6Pool responses
+func (resp *IPv6PoolsPagedResponse) appendData(r *IPv6PoolsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of IPv6Pool
-func (IPv6PoolsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of IPv6Pool
+func (IPv6PoolsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(IPv6PoolsPagedResponse{})
 }
 
 // ListIPv6Pools lists IPv6Pools
 func (c *Client) ListIPv6Pools(opts *ListOptions) ([]*IPv6Range, error) {
 	response := IPv6PoolsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/network_ranges.go
+++ b/network_ranges.go
@@ -12,8 +12,8 @@ type IPv6RangesPagedResponse struct {
 	Data []*IPv6Range
 }
 
-// Endpoint gets the endpoint URL for IPv6Range
-func (IPv6RangesPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for IPv6Range
+func (IPv6RangesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.IPv6Ranges.Endpoint()
 	if err != nil {
 		panic(err)
@@ -21,20 +21,20 @@ func (IPv6RangesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends IPv6Ranges when processing paginated IPv6Range responses
-func (resp *IPv6RangesPagedResponse) AppendData(r *IPv6RangesPagedResponse) {
+// appendData appends IPv6Ranges when processing paginated IPv6Range responses
+func (resp *IPv6RangesPagedResponse) appendData(r *IPv6RangesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of IPv6Range
-func (IPv6RangesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of IPv6Range
+func (IPv6RangesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(IPv6RangesPagedResponse{})
 }
 
 // ListIPv6Ranges lists IPv6Ranges
 func (c *Client) ListIPv6Ranges(opts *ListOptions) ([]*IPv6Range, error) {
 	response := IPv6RangesPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -28,7 +28,7 @@ type NodeBalancersPagedResponse struct {
 	Data []*NodeBalancer
 }
 
-func (NodeBalancersPagedResponse) Endpoint(c *Client) string {
+func (NodeBalancersPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.NodeBalancers.Endpoint()
 	if err != nil {
 		panic(err)
@@ -36,18 +36,18 @@ func (NodeBalancersPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-func (resp *NodeBalancersPagedResponse) AppendData(r *NodeBalancersPagedResponse) {
+func (resp *NodeBalancersPagedResponse) appendData(r *NodeBalancersPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-func (NodeBalancersPagedResponse) SetResult(r *resty.Request) {
+func (NodeBalancersPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(NodeBalancersPagedResponse{})
 }
 
 // ListNodeBalancers lists NodeBalancers
 func (c *Client) ListNodeBalancers(opts *ListOptions) ([]*NodeBalancer, error) {
 	response := NodeBalancersPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/nodebalancer_config_nodes.go
+++ b/nodebalancer_config_nodes.go
@@ -23,29 +23,29 @@ type NodeBalancerNodesPagedResponse struct {
 	Data []*NodeBalancerNode
 }
 
-// Endpoint gets the endpoint URL for NodeBalancerNode
-func (NodeBalancerNodesPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.NodeBalancerNodes.EndpointWithID(id)
+// endpoint gets the endpoint URL for NodeBalancerNode
+func (NodeBalancerNodesPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.NodeBalancerNodes.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends NodeBalancerNodes when processing paginated NodeBalancerNode responses
-func (resp *NodeBalancerNodesPagedResponse) AppendData(r *NodeBalancerNodesPagedResponse) {
+// appendData appends NodeBalancerNodes when processing paginated NodeBalancerNode responses
+func (resp *NodeBalancerNodesPagedResponse) appendData(r *NodeBalancerNodesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of NodeBalancerNode
-func (NodeBalancerNodesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of NodeBalancerNode
+func (NodeBalancerNodesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(NodeBalancerNodesPagedResponse{})
 }
 
 // ListNodeBalancerNodes lists NodeBalancerNodes
 func (c *Client) ListNodeBalancerNodes(nodebalancerID int, configID int, opts *ListOptions) ([]*NodeBalancerNode, error) {
 	response := NodeBalancerNodesPagedResponse{}
-	err := c.ListHelperWithID(&response, nodebalancerID, opts)
+	err := c.listHelperWithID(&response, nodebalancerID, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}
@@ -62,7 +62,7 @@ func (v *NodeBalancerNode) fixDates() *NodeBalancerNode {
 
 // GetNodeBalancerNode gets the template with the provided ID
 func (c *Client) GetNodeBalancerNode(nodebalancerID int, configID int, nodeID int) (*NodeBalancerNode, error) {
-	e, err := c.NodeBalancerConfigs.EndpointWithID(nodebalancerID)
+	e, err := c.NodeBalancerConfigs.endpointWithID(nodebalancerID)
 	if err != nil {
 		return nil, err
 	}

--- a/nodebalancer_configs.go
+++ b/nodebalancer_configs.go
@@ -38,29 +38,29 @@ type NodeBalancerConfigsPagedResponse struct {
 	Data []*NodeBalancerConfig
 }
 
-// Endpoint gets the endpoint URL for NodeBalancerConfig
-func (NodeBalancerConfigsPagedResponse) EndpointWithID(c *Client, id int) string {
-	endpoint, err := c.NodeBalancerConfigs.EndpointWithID(id)
+// endpoint gets the endpoint URL for NodeBalancerConfig
+func (NodeBalancerConfigsPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.NodeBalancerConfigs.endpointWithID(id)
 	if err != nil {
 		panic(err)
 	}
 	return endpoint
 }
 
-// AppendData appends NodeBalancerConfigs when processing paginated NodeBalancerConfig responses
-func (resp *NodeBalancerConfigsPagedResponse) AppendData(r *NodeBalancerConfigsPagedResponse) {
+// appendData appends NodeBalancerConfigs when processing paginated NodeBalancerConfig responses
+func (resp *NodeBalancerConfigsPagedResponse) appendData(r *NodeBalancerConfigsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of NodeBalancerConfig
-func (NodeBalancerConfigsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of NodeBalancerConfig
+func (NodeBalancerConfigsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(NodeBalancerConfigsPagedResponse{})
 }
 
 // ListNodeBalancerConfigs lists NodeBalancerConfigs
 func (c *Client) ListNodeBalancerConfigs(nodebalancerID int, opts *ListOptions) ([]*NodeBalancerConfig, error) {
 	response := NodeBalancerConfigsPagedResponse{}
-	err := c.ListHelperWithID(&response, nodebalancerID, opts)
+	err := c.listHelperWithID(&response, nodebalancerID, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}
@@ -77,7 +77,7 @@ func (v *NodeBalancerConfig) fixDates() *NodeBalancerConfig {
 
 // GetNodeBalancerConfig gets the template with the provided ID
 func (c *Client) GetNodeBalancerConfig(nodebalancerID int, configID int) (*NodeBalancerConfig, error) {
-	e, err := c.NodeBalancerConfigs.EndpointWithID(nodebalancerID)
+	e, err := c.NodeBalancerConfigs.endpointWithID(nodebalancerID)
 	if err != nil {
 		return nil, err
 	}

--- a/pagination.go
+++ b/pagination.go
@@ -30,10 +30,10 @@ type PagedResponse struct {
 }
 
 type ListResponse interface {
-	Endpoint(*Client) string
-	AppendData(*resty.Response)
-	SetResult(*resty.Request)
-	ListHelper(*resty.Request, *ListOptions) *Error
+	endpoint(*Client) string
+	appendData(*resty.Response)
+	setResult(*resty.Request)
+	listHelper(*resty.Request, *ListOptions) *Error
 }
 
 // NewListOptions simplified construction of ListOptions using only
@@ -43,12 +43,12 @@ func NewListOptions(Page int, Filter string) *ListOptions {
 
 }
 
-// ListHelper abstracts fetching and pagination for GET endpoints that
+// listHelper abstracts fetching and pagination for GET endpoints that
 // do not require any Ids (top level endpoints).
 // When opts (or opts.Page) is nil, all pages will be fetched and
 // returned in a single (endpoint-specific)PagedResponse
 // opts.results and opts.pages will be updated from the API response
-func (c *Client) ListHelper(i interface{}, opts *ListOptions) error {
+func (c *Client) listHelper(i interface{}, opts *ListOptions) error {
 	req := c.R()
 	if opts != nil && opts.PageOptions != nil && opts.Page > 0 {
 		req.SetQueryParam("page", strconv.Itoa(opts.Page))
@@ -67,194 +67,194 @@ func (c *Client) ListHelper(i interface{}, opts *ListOptions) error {
 
 	switch v := i.(type) {
 	case *LinodeKernelsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(LinodeKernelsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(LinodeKernelsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*LinodeKernelsPagedResponse).Pages
 			results = r.Result().(*LinodeKernelsPagedResponse).Results
-			v.AppendData(r.Result().(*LinodeKernelsPagedResponse))
+			v.appendData(r.Result().(*LinodeKernelsPagedResponse))
 		}
 	case *LinodeTypesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(LinodeTypesPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(LinodeTypesPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*LinodeTypesPagedResponse).Pages
 			results = r.Result().(*LinodeTypesPagedResponse).Results
-			v.AppendData(r.Result().(*LinodeTypesPagedResponse))
+			v.appendData(r.Result().(*LinodeTypesPagedResponse))
 		}
 	case *ImagesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(ImagesPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(ImagesPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*ImagesPagedResponse).Pages
 			results = r.Result().(*ImagesPagedResponse).Results
-			v.AppendData(r.Result().(*ImagesPagedResponse))
+			v.appendData(r.Result().(*ImagesPagedResponse))
 		}
 	case *StackscriptsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(StackscriptsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(StackscriptsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*StackscriptsPagedResponse).Pages
 			results = r.Result().(*StackscriptsPagedResponse).Results
-			v.AppendData(r.Result().(*StackscriptsPagedResponse))
+			v.appendData(r.Result().(*StackscriptsPagedResponse))
 		}
 	case *InstancesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(InstancesPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(InstancesPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*InstancesPagedResponse).Pages
 			results = r.Result().(*InstancesPagedResponse).Results
-			v.AppendData(r.Result().(*InstancesPagedResponse))
+			v.appendData(r.Result().(*InstancesPagedResponse))
 		}
 	case *RegionsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(RegionsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(RegionsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*RegionsPagedResponse).Pages
 			results = r.Result().(*RegionsPagedResponse).Results
-			v.AppendData(r.Result().(*RegionsPagedResponse))
+			v.appendData(r.Result().(*RegionsPagedResponse))
 		}
 	case *VolumesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(VolumesPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(VolumesPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*VolumesPagedResponse).Pages
 			results = r.Result().(*VolumesPagedResponse).Results
-			v.AppendData(r.Result().(*VolumesPagedResponse))
+			v.appendData(r.Result().(*VolumesPagedResponse))
 		}
 	case *EventsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(EventsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(EventsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*EventsPagedResponse).Pages
 			results = r.Result().(*EventsPagedResponse).Results
-			v.AppendData(r.Result().(*EventsPagedResponse))
+			v.appendData(r.Result().(*EventsPagedResponse))
 		}
 	case *LongviewSubscriptionsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(LongviewSubscriptionsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(LongviewSubscriptionsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*LongviewSubscriptionsPagedResponse).Pages
 			results = r.Result().(*LongviewSubscriptionsPagedResponse).Results
-			v.AppendData(r.Result().(*LongviewSubscriptionsPagedResponse))
+			v.appendData(r.Result().(*LongviewSubscriptionsPagedResponse))
 		}
 	case *LongviewClientsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(LongviewClientsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(LongviewClientsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*LongviewClientsPagedResponse).Pages
 			results = r.Result().(*LongviewClientsPagedResponse).Results
-			v.AppendData(r.Result().(*LongviewClientsPagedResponse))
+			v.appendData(r.Result().(*LongviewClientsPagedResponse))
 		}
 	case *IPAddressesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(IPAddressesPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(IPAddressesPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*IPAddressesPagedResponse).Pages
 			results = r.Result().(*IPAddressesPagedResponse).Results
-			v.AppendData(r.Result().(*IPAddressesPagedResponse))
+			v.appendData(r.Result().(*IPAddressesPagedResponse))
 		}
 	case *IPv6PoolsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(IPv6PoolsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(IPv6PoolsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*IPv6PoolsPagedResponse).Pages
 			results = r.Result().(*IPv6PoolsPagedResponse).Results
-			v.AppendData(r.Result().(*IPv6PoolsPagedResponse))
+			v.appendData(r.Result().(*IPv6PoolsPagedResponse))
 		}
 	case *IPv6RangesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(IPv6RangesPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(IPv6RangesPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*IPv6RangesPagedResponse).Pages
 			results = r.Result().(*IPv6RangesPagedResponse).Results
-			v.AppendData(r.Result().(*IPv6RangesPagedResponse))
+			v.appendData(r.Result().(*IPv6RangesPagedResponse))
 			// @TODO consolidate this type with IPv6PoolsPagedResponse?
 		}
 	case *TicketsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(TicketsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(TicketsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*TicketsPagedResponse).Pages
 			results = r.Result().(*TicketsPagedResponse).Results
-			v.AppendData(r.Result().(*TicketsPagedResponse))
+			v.appendData(r.Result().(*TicketsPagedResponse))
 		}
 	case *InvoicesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(InvoicesPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(InvoicesPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*InvoicesPagedResponse).Pages
 			results = r.Result().(*InvoicesPagedResponse).Results
-			v.AppendData(r.Result().(*InvoicesPagedResponse))
+			v.appendData(r.Result().(*InvoicesPagedResponse))
 		}
 	case *NotificationsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(NotificationsPagedResponse{}).Get(v.Endpoint(c))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(NotificationsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			pages = r.Result().(*NotificationsPagedResponse).Pages
 			results = r.Result().(*NotificationsPagedResponse).Results
-			v.AppendData(r.Result().(*NotificationsPagedResponse))
+			v.appendData(r.Result().(*NotificationsPagedResponse))
 		}
 	/**
 	case AccountOauthClientsPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*AccountOauthClientsPagedResponse).Pages
 			results = r.Result().(*AccountOauthClientsPagedResponse).Results
-			v.AppendData(r.Result().(*AccountOauthClientsPagedResponse))
+			v.appendData(r.Result().(*AccountOauthClientsPagedResponse))
 		}
 	case AccountPaymentsPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*AccountPaymentsPagedResponse).Pages
 			results = r.Result().(*AccountPaymentsPagedResponse).Results
-			v.AppendData(r.Result().(*AccountPaymentsPagedResponse))
+			v.appendData(r.Result().(*AccountPaymentsPagedResponse))
 		}
 	case AccountUsersPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*AccountUsersPagedResponse).Pages
 			results = r.Result().(*AccountUsersPagedResponse).Results
-			v.AppendData(r.Result().(*AccountUsersPagedResponse))
+			v.appendData(r.Result().(*AccountUsersPagedResponse))
 		}
 	case ProfileAppsPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ProfileAppsPagedResponse).Pages
 			results = r.Result().(*ProfileAppsPagedResponse).Results
-			v.AppendData(r.Result().(*ProfileAppsPagedResponse))
+			v.appendData(r.Result().(*ProfileAppsPagedResponse))
 		}
 	case ProfileTokensPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ProfileTokensPagedResponse).Pages
 			results = r.Result().(*ProfileTokensPagedResponse).Results
-			v.AppendData(r.Result().(*ProfileTokensPagedResponse))
+			v.appendData(r.Result().(*ProfileTokensPagedResponse))
 		}
 	case ProfileWhitelistPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ProfileWhitelistPagedResponse).Pages
 			results = r.Result().(*ProfileWhitelistPagedResponse).Results
-			v.AppendData(r.Result().(*ProfileWhitelistPagedResponse))
+			v.appendData(r.Result().(*ProfileWhitelistPagedResponse))
 		}
 	case ManagedContactsPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ManagedContactsPagedResponse).Pages
 			results = r.Result().(*ManagedContactsPagedResponse).Results
-			v.AppendData(r.Result().(*ManagedContactsPagedResponse))
+			v.appendData(r.Result().(*ManagedContactsPagedResponse))
 		}
 	case ManagedCredentialsPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ManagedCredentialsPagedResponse).Pages
 			results = r.Result().(*ManagedCredentialsPagedResponse).Results
-			v.AppendData(r.Result().(*ManagedCredentialsPagedResponse))
+			v.appendData(r.Result().(*ManagedCredentialsPagedResponse))
 		}
 	case ManagedIssuesPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ManagedIssuesPagedResponse).Pages
 			results = r.Result().(*ManagedIssuesPagedResponse).Results
-			v.AppendData(r.Result().(*ManagedIssuesPagedResponse))
+			v.appendData(r.Result().(*ManagedIssuesPagedResponse))
 		}
 	case ManagedLinodeSettingsPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ManagedLinodeSettingsPagedResponse).Pages
 			results = r.Result().(*ManagedLinodeSettingsPagedResponse).Results
-			v.AppendData(r.Result().(*ManagedLinodeSettingsPagedResponse))
+			v.appendData(r.Result().(*ManagedLinodeSettingsPagedResponse))
 		}
 	case ManagedServicesPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*ManagedServicesPagedResponse).Pages
 			results = r.Result().(*ManagedServicesPagedResponse).Results
-			v.AppendData(r.Result().(*ManagedServicesPagedResponse))
+			v.appendData(r.Result().(*ManagedServicesPagedResponse))
 		}
 	**/
 	default:
-		log.Fatalf("ListHelper interface{} %+v used", i)
+		log.Fatalf("listHelper interface{} %+v used", i)
 	}
 
 	if err != nil {
@@ -263,7 +263,7 @@ func (c *Client) ListHelper(i interface{}, opts *ListOptions) error {
 
 	if opts == nil {
 		for page := 2; page <= pages; page = page + 1 {
-			c.ListHelper(i, &ListOptions{PageOptions: &PageOptions{Page: page}})
+			c.listHelper(i, &ListOptions{PageOptions: &PageOptions{Page: page}})
 		}
 	} else {
 		if opts.PageOptions == nil {
@@ -273,7 +273,7 @@ func (c *Client) ListHelper(i interface{}, opts *ListOptions) error {
 		if opts.Page == 0 {
 			for page := 2; page <= pages; page = page + 1 {
 				opts.Page = page
-				c.ListHelper(i, opts)
+				c.listHelper(i, opts)
 			}
 		}
 		opts.Results = results
@@ -283,12 +283,12 @@ func (c *Client) ListHelper(i interface{}, opts *ListOptions) error {
 	return nil
 }
 
-// ListHelperWithID abstracts fetching and pagination for GET endpoints that
+// listHelperWithID abstracts fetching and pagination for GET endpoints that
 // require an Id (second level endpoints).
 // When opts (or opts.Page) is nil, all pages will be fetched and
 // returned in a single (endpoint-specific)PagedResponse
 // opts.results and opts.pages will be updated from the API response
-func (c *Client) ListHelperWithID(i interface{}, id int, opts *ListOptions) error {
+func (c *Client) listHelperWithID(i interface{}, id int, opts *ListOptions) error {
 	req := c.R()
 	if opts != nil && opts.Page > 0 {
 		req.SetQueryParam("page", strconv.Itoa(opts.Page))
@@ -307,67 +307,67 @@ func (c *Client) ListHelperWithID(i interface{}, id int, opts *ListOptions) erro
 
 	switch v := i.(type) {
 	case *InvoiceItemsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(InvoiceItemsPagedResponse{}).Get(v.EndpointWithID(c, id))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(InvoiceItemsPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
 			pages = r.Result().(*InvoiceItemsPagedResponse).Pages
 			results = r.Result().(*InvoiceItemsPagedResponse).Results
-			v.AppendData(r.Result().(*InvoiceItemsPagedResponse))
+			v.appendData(r.Result().(*InvoiceItemsPagedResponse))
 		}
 	case *DomainRecordsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(DomainRecordsPagedResponse{}).Get(v.EndpointWithID(c, id))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(DomainRecordsPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
 			pages = r.Result().(*DomainRecordsPagedResponse).Pages
 			results = r.Result().(*DomainRecordsPagedResponse).Results
-			v.AppendData(r.Result().(*DomainRecordsPagedResponse))
+			v.appendData(r.Result().(*DomainRecordsPagedResponse))
 		}
 	case *InstanceSnapshotsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(InstanceSnapshotsPagedResponse{}).Get(v.EndpointWithID(c, id))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(InstanceSnapshotsPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
 			pages = r.Result().(*InstanceSnapshotsPagedResponse).Pages
 			results = r.Result().(*InstanceSnapshotsPagedResponse).Results
-			v.AppendData(r.Result().(*InstanceSnapshotsPagedResponse))
+			v.appendData(r.Result().(*InstanceSnapshotsPagedResponse))
 		}
 	case *InstanceConfigsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(InstanceConfigsPagedResponse{}).Get(v.EndpointWithID(c, id))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(InstanceConfigsPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
 			pages = r.Result().(*InstanceConfigsPagedResponse).Pages
 			results = r.Result().(*InstanceConfigsPagedResponse).Results
-			v.AppendData(r.Result().(*InstanceConfigsPagedResponse))
+			v.appendData(r.Result().(*InstanceConfigsPagedResponse))
 		}
 	case *InstanceDisksPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(InstanceDisksPagedResponse{}).Get(v.EndpointWithID(c, id))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(InstanceDisksPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
 			pages = r.Result().(*InstanceDisksPagedResponse).Pages
 			results = r.Result().(*InstanceDisksPagedResponse).Results
-			v.AppendData(r.Result().(*InstanceDisksPagedResponse))
+			v.appendData(r.Result().(*InstanceDisksPagedResponse))
 		}
 	case *NodeBalancerConfigsPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(NodeBalancerConfigsPagedResponse{}).Get(v.EndpointWithID(c, id))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(NodeBalancerConfigsPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
 			pages = r.Result().(*NodeBalancerConfigsPagedResponse).Pages
 			results = r.Result().(*NodeBalancerConfigsPagedResponse).Results
-			v.AppendData(r.Result().(*NodeBalancerConfigsPagedResponse))
+			v.appendData(r.Result().(*NodeBalancerConfigsPagedResponse))
 		}
 	case *InstanceVolumesPagedResponse:
-		if r, err = coupleAPIErrors(req.SetResult(InstanceVolumesPagedResponse{}).Get(v.EndpointWithID(c, id))); err == nil {
+		if r, err = coupleAPIErrors(req.SetResult(InstanceVolumesPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
 			pages = r.Result().(*InstanceVolumesPagedResponse).Pages
 			results = r.Result().(*InstanceVolumesPagedResponse).Results
-			v.AppendData(r.Result().(*InstanceVolumesPagedResponse))
+			v.appendData(r.Result().(*InstanceVolumesPagedResponse))
 		}
 	/**
 	case TicketAttachmentsPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*TicketAttachmentsPagedResponse).Pages
 			results = r.Result().(*TicketAttachmentsPagedResponse).Results
-			v.AppendData(r.Result().(*TicketAttachmentsPagedResponse))
+			v.appendData(r.Result().(*TicketAttachmentsPagedResponse))
 		}
 	case TicketRepliesPagedResponse:
-		if r, err = req.SetResult(v).Get(v.Endpoint(c)); r.Error() != nil {
+		if r, err = req.SetResult(v).Get(v.endpoint(c)); r.Error() != nil {
 			return NewError(r)
 		} else if err == nil {
 			pages = r.Result().(*TicketRepliesPagedResponse).Pages
 			results = r.Result().(*TicketRepliesPagedResponse).Results
-			v.AppendData(r.Result().(*TicketRepliesPagedResponse))
+			v.appendData(r.Result().(*TicketRepliesPagedResponse))
 		}
 	**/
 	default:
-		log.Fatalf("Unknown ListHelperWithID interface{} %T used", i)
+		log.Fatalf("Unknown listHelperWithID interface{} %T used", i)
 	}
 
 	if err != nil {
@@ -376,7 +376,7 @@ func (c *Client) ListHelperWithID(i interface{}, id int, opts *ListOptions) erro
 
 	if opts == nil {
 		for page := 2; page <= pages; page = page + 1 {
-			c.ListHelper(i, &ListOptions{PageOptions: &PageOptions{Page: page}})
+			c.listHelper(i, &ListOptions{PageOptions: &PageOptions{Page: page}})
 		}
 	} else {
 		if opts.PageOptions == nil {
@@ -385,7 +385,7 @@ func (c *Client) ListHelperWithID(i interface{}, id int, opts *ListOptions) erro
 		if opts.Page == 0 {
 			for page := 2; page <= pages; page = page + 1 {
 				opts.Page = page
-				c.ListHelper(i, opts)
+				c.listHelper(i, opts)
 			}
 		}
 		opts.Results = results

--- a/pagination.go
+++ b/pagination.go
@@ -24,12 +24,12 @@ type ListOptions struct {
 	Filter string
 }
 
-type PagedResponse struct {
-	ListResponse
+type pagedResponse struct {
+	listResponse
 	*PageOptions
 }
 
-type ListResponse interface {
+type listResponse interface {
 	endpoint(*Client) string
 	appendData(*resty.Response)
 	setResult(*resty.Request)

--- a/regions.go
+++ b/regions.go
@@ -18,8 +18,8 @@ type RegionsPagedResponse struct {
 	Data []*Region
 }
 
-// Endpoint gets the endpoint URL for Region
-func (RegionsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Region
+func (RegionsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Regions.Endpoint()
 	if err != nil {
 		panic(err)
@@ -27,20 +27,20 @@ func (RegionsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Regions when processing paginated Region responses
-func (resp *RegionsPagedResponse) AppendData(r *RegionsPagedResponse) {
+// appendData appends Regions when processing paginated Region responses
+func (resp *RegionsPagedResponse) appendData(r *RegionsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Region
-func (RegionsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Region
+func (RegionsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(RegionsPagedResponse{})
 }
 
 // ListRegions lists Regions
 func (c *Client) ListRegions(opts *ListOptions) ([]*Region, error) {
 	response := RegionsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/resources.go
+++ b/resources.go
@@ -115,8 +115,8 @@ func (r Resource) render(data interface{}) (string, error) {
 	return buf.String(), nil
 }
 
-// EndpointWithID will return the rendered endpoint string for the resource with provided id
-func (r Resource) EndpointWithID(id int) (string, error) {
+// endpointWithID will return the rendered endpoint string for the resource with provided id
+func (r Resource) endpointWithID(id int) (string, error) {
 	if !r.isTemplate {
 		return r.endpoint, nil
 	}

--- a/resources_test.go
+++ b/resources_test.go
@@ -18,11 +18,11 @@ func TestResourceEndpoint(t *testing.T) {
 		t.Errorf("Images endpoint did not match '%s'", imagesEndpoint)
 	}
 }
-func TestResourceTemplatedEndpointWithID(t *testing.T) {
+func TestResourceTemplatedendpointWithID(t *testing.T) {
 	apiKey := "MYFAKEAPIKEY"
 	client := NewClient(&apiKey, nil)
 	backupID := 1234255
-	e, err := client.InstanceSnapshots.EndpointWithID(backupID)
+	e, err := client.InstanceSnapshots.endpointWithID(backupID)
 	if err != nil {
 		t.Error("Got error when getting endpoint with id for backups")
 	}

--- a/stackscripts.go
+++ b/stackscripts.go
@@ -34,8 +34,8 @@ type StackscriptsPagedResponse struct {
 	Data []*Stackscript
 }
 
-// Endpoint gets the endpoint URL for Stackscript
-func (StackscriptsPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Stackscript
+func (StackscriptsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.StackScripts.Endpoint()
 	if err != nil {
 		panic(err)
@@ -43,20 +43,20 @@ func (StackscriptsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Stackscripts when processing paginated Stackscript responses
-func (resp *StackscriptsPagedResponse) AppendData(r *StackscriptsPagedResponse) {
+// appendData appends Stackscripts when processing paginated Stackscript responses
+func (resp *StackscriptsPagedResponse) appendData(r *StackscriptsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Stackscript
-func (StackscriptsPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Stackscript
+func (StackscriptsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(StackscriptsPagedResponse{})
 }
 
 // ListStackscripts lists Stackscripts
 func (c *Client) ListStackscripts(opts *ListOptions) ([]*Stackscript, error) {
 	response := StackscriptsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/support.go
+++ b/support.go
@@ -44,7 +44,7 @@ type TicketsPagedResponse struct {
 	Data []*Ticket
 }
 
-func (TicketsPagedResponse) Endpoint(c *Client) string {
+func (TicketsPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Tickets.Endpoint()
 	if err != nil {
 		panic(err)
@@ -52,11 +52,11 @@ func (TicketsPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-func (resp *TicketsPagedResponse) AppendData(r *TicketsPagedResponse) {
+func (resp *TicketsPagedResponse) appendData(r *TicketsPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-func (TicketsPagedResponse) SetResult(r *resty.Request) {
+func (TicketsPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(TicketsPagedResponse{})
 }
 
@@ -66,7 +66,7 @@ func (TicketsPagedResponse) SetResult(r *resty.Request) {
 // on the Account, with open tickets returned first.
 func (c *Client) ListTickets(opts *ListOptions) ([]*Ticket, error) {
 	response := TicketsPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/template.go.example
+++ b/template.go.example
@@ -19,8 +19,8 @@ type TemplatesPagedResponse struct {
 	Data []*Template
 }
 
-// Endpoint gets the endpoint URL for Template
-func (TemplatesPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Template
+func (TemplatesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Templates.Endpoint()
 	if err != nil {
 		panic(err)
@@ -28,20 +28,20 @@ func (TemplatesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Templates when processing paginated Template responses
-func (resp *TemplatesPagedResponse) AppendData(r *TemplatesPagedResponse) {
+// appendData appends Templates when processing paginated Template responses
+func (resp *TemplatesPagedResponse) appendData(r *TemplatesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Template
-func (TemplatesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Template
+func (TemplatesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(TemplatesPagedResponse{})
 }
 
 // ListTemplates lists Templates
 func (c *Client) ListTemplates(opts *ListOptions) ([]*Template, error) {
 	response := TemplatesPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}

--- a/types.go
+++ b/types.go
@@ -42,7 +42,7 @@ type LinodeTypesPagedResponse struct {
 	Data []*LinodeType
 }
 
-func (LinodeTypesPagedResponse) Endpoint(c *Client) string {
+func (LinodeTypesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Types.Endpoint()
 	if err != nil {
 		panic(err)
@@ -50,18 +50,18 @@ func (LinodeTypesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-func (resp *LinodeTypesPagedResponse) AppendData(r *LinodeTypesPagedResponse) {
+func (resp *LinodeTypesPagedResponse) appendData(r *LinodeTypesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-func (LinodeTypesPagedResponse) SetResult(r *resty.Request) {
+func (LinodeTypesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(LinodeTypesPagedResponse{})
 }
 
 // ListTypes lists linode types
 func (c *Client) ListTypes(opts *ListOptions) ([]*LinodeType, error) {
 	response := LinodeTypesPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/volumes.go
+++ b/volumes.go
@@ -34,8 +34,8 @@ type VolumesPagedResponse struct {
 	Data []*Volume
 }
 
-// Endpoint gets the endpoint URL for Volume
-func (VolumesPagedResponse) Endpoint(c *Client) string {
+// endpoint gets the endpoint URL for Volume
+func (VolumesPagedResponse) endpoint(c *Client) string {
 	endpoint, err := c.Volumes.Endpoint()
 	if err != nil {
 		panic(err)
@@ -43,20 +43,20 @@ func (VolumesPagedResponse) Endpoint(c *Client) string {
 	return endpoint
 }
 
-// AppendData appends Volumes when processing paginated Volume responses
-func (resp *VolumesPagedResponse) AppendData(r *VolumesPagedResponse) {
+// appendData appends Volumes when processing paginated Volume responses
+func (resp *VolumesPagedResponse) appendData(r *VolumesPagedResponse) {
 	(*resp).Data = append(resp.Data, r.Data...)
 }
 
-// SetResult sets the Resty response type of Volume
-func (VolumesPagedResponse) SetResult(r *resty.Request) {
+// setResult sets the Resty response type of Volume
+func (VolumesPagedResponse) setResult(r *resty.Request) {
 	r.SetResult(VolumesPagedResponse{})
 }
 
 // ListVolumes lists Volumes
 func (c *Client) ListVolumes(opts *ListOptions) ([]*Volume, error) {
 	response := VolumesPagedResponse{}
-	err := c.ListHelper(&response, opts)
+	err := c.listHelper(&response, opts)
 	for _, el := range response.Data {
 		el.fixDates()
 	}


### PR DESCRIPTION
Make some internals private because these particular internals, related to URL fetching and pagination, could easily get refactored away.