### PR TITLE
Add Event polling

### DIFF
--- a/API_SUPPORT.md
+++ b/API_SUPPORT.md
@@ -92,11 +92,11 @@
 
 - `/linode/stackscripts`
   - [x] `GET`
-  - [ ] `POST`
+  - [X] `POST`
 - `/linode/stackscripts/$id`
   - [x] `GET`
-  - [ ] `PUT`
-  - [ ] `DELETE`
+  - [X] `PUT`
+  - [X] `DELETE`
 
 ### Stats
 

--- a/account_events.go
+++ b/account_events.go
@@ -9,20 +9,120 @@ import (
 // Event represents an action taken on the Account.
 type Event struct {
 	CreatedStr string `json:"created"`
-	UpdatedStr string `json:"updated"`
 
-	ID              int
-	Status          string
-	Action          string
+	// The unique ID of this Event.
+	ID int
+
+	// Current status of the Event, Enum: "failed" "finished" "notification" "scheduled" "started"
+	Status EventStatus
+
+	// The action that caused this Event. New actions may be added in the future.
+	Action EventAction
+
+	// A percentage estimating the amount of time remaining for an Event. Returns null for notification events.
 	PercentComplete int `json:"percent_complete"`
-	Rate            string
-	Read            bool
-	Seen            bool
-	TimeRemaining   int
-	Username        string
-	Entity          *EventEntity
-	Created         *time.Time `json:"-"`
+
+	// The rate of completion of the Event. Only some Events will return rate; for example, migration and resize Events.
+	Rate string
+
+	// If this Event has been read.
+	Read bool
+
+	// If this Event has been seen.
+	Seen bool
+
+	// The estimated time remaining until the completion of this Event. This value is only returned for in-progress events.
+	TimeRemaining int
+
+	// The username of the User who caused the Event.
+	Username string
+
+	// Detailed information about the Event's entity, including ID, type, label, and URL used to access it.
+	Entity *EventEntity
+
+	// When this Event was created.
+	Created *time.Time `json:"-"`
 }
+
+// EventAction constants start with Action and include all known Linode API Event Actions.
+type EventAction string
+
+const (
+	ActionBackupsEnable            EventAction = "backups_enable"
+	ActionBackupsCancel            EventAction = "backups_cancel"
+	ActionBackupsRestore           EventAction = "backups_restore"
+	ActionCommunityQuestionReply   EventAction = "community_question_reply"
+	ActionCreateCardUpdated        EventAction = "credit_card_updated"
+	ActionDiskCreate               EventAction = "disk_create"
+	ActionDiskDelete               EventAction = "disk_delete"
+	ActionDiskDuplicate            EventAction = "disk_duplicate"
+	ActionDiskImagize              EventAction = "disk_imagize"
+	ActionDiskResize               EventAction = "disk_resize"
+	ActionDNSRecordCreate          EventAction = "dns_record_create"
+	ActionDNSRecordDelete          EventAction = "dns_record_delete"
+	ActionDNSZoneCreate            EventAction = "dns_zone_create"
+	ActionDNSZoneDelete            EventAction = "dns_zone_delete"
+	ActionImageDelete              EventAction = "image_delete"
+	ActionLinodeAddIP              EventAction = "linode_addip"
+	ActionLinodeBoot               EventAction = "linode_boot"
+	ActionLinodeClone              EventAction = "linode_clone"
+	ActionLinodeCreate             EventAction = "linode_create"
+	ActionLinodeDelete             EventAction = "linode_delete"
+	ActionLinodeDeleteIP           EventAction = "linode_deleteip"
+	ActionLinodeMigrate            EventAction = "linode_migrate"
+	ActionLinodeMutate             EventAction = "linode_mutate"
+	ActionLinodeReboot             EventAction = "linode_reboot"
+	ActionLinodeRebuild            EventAction = "linode_rebuild"
+	ActionLinodeResize             EventAction = "linode_resize"
+	ActionLinodeShutdown           EventAction = "linode_shutdown"
+	ActionLinodeSnapshot           EventAction = "linode_snapshot"
+	ActionLongviewClientCreate     EventAction = "longviewclient_create"
+	ActionLongviewClientDelete     EventAction = "longviewclient_delete"
+	ActionManagedDisabled          EventAction = "managed_disabled"
+	ActionManagedEnabled           EventAction = "managed_enabled"
+	ActionManagedServiceCreate     EventAction = "managed_service_create"
+	ActionManagedServiceDelete     EventAction = "managed_service_delete"
+	ActionNodebalancerCreate       EventAction = "nodebalancer_create"
+	ActionNodebalancerDelete       EventAction = "nodebalancer_delete"
+	ActionNodebalancerConfigCreate EventAction = "nodebalancer_config_create"
+	ActionNodebalancerConfigDelete EventAction = "nodebalancer_config_delete"
+	ActionPasswordReset            EventAction = "password_reset"
+	ActionPaymentSubmitted         EventAction = "payment_submitted"
+	ActionStackScriptCreate        EventAction = "stackscript_create"
+	ActionStackScriptDelete        EventAction = "stackscript_delete"
+	ActionStackScriptPublicize     EventAction = "stackscript_publicize"
+	ActionStackScriptRevise        EventAction = "stackscript_revise"
+	ActionTFADisabled              EventAction = "tfa_disabled"
+	ActionTFAEnabled               EventAction = "tfa_enabled"
+	ActionTicketAttachmentUpload   EventAction = "ticket_attachment_upload"
+	ActionTicketCreate             EventAction = "ticket_create"
+	ActionTicketReply              EventAction = "ticket_reply"
+	ActionVolumeAttach             EventAction = "volume_attach"
+	ActionVolumeClone              EventAction = "volume_clone"
+	ActionVolumeCreate             EventAction = "volume_create"
+	ActionVolumeDelte              EventAction = "volume_delete"
+	ActionVolumeDetach             EventAction = "volume_detach"
+	ActionVolumeResize             EventAction = "volume_resize"
+)
+
+// EntityType constants start with Entity and include Linode API Event Entity Types
+type EntityType string
+
+const (
+	EntityLinode EntityType = "linode"
+	EntityDisk   EntityType = "disk"
+)
+
+// EventStatus constants start with Event and include Linode API Event Status values
+type EventStatus string
+
+const (
+	EventFailed       EventStatus = "failed"
+	EventFinished     EventStatus = "finished"
+	EventNotification EventStatus = "notification"
+	EventScheduled    EventStatus = "scheduled"
+	EventStarted      EventStatus = "started"
+)
 
 // EventEntity provides detailed information about the Event's
 // associated entity, including ID, Type, Label, and a URL that
@@ -30,7 +130,7 @@ type Event struct {
 type EventEntity struct {
 	ID    int
 	Label string
-	Type  string
+	Type  EntityType
 	URL   string
 }
 

--- a/account_events.go
+++ b/account_events.go
@@ -204,8 +204,8 @@ func (c *Client) MarkEventRead(event *Event) error {
 	return nil
 }
 
-// MarkEventSeen marks all Events up to and including this Event by ID as seen.
-func (c *Client) MarkEventSeen(event *Event) error {
+// MarkEventsSeen marks all Events up to and including this Event by ID as seen.
+func (c *Client) MarkEventsSeen(event *Event) error {
 	e := event.endpointWithID(c)
 	e = fmt.Sprintf("%s/seen", e)
 

--- a/account_events.go
+++ b/account_events.go
@@ -128,7 +128,8 @@ const (
 // associated entity, including ID, Type, Label, and a URL that
 // can be used to access it.
 type EventEntity struct {
-	ID    int
+	// ID may be a string or int, it depends on the EntityType
+	ID    interface{}
 	Label string
 	Type  EntityType
 	URL   string

--- a/client.go
+++ b/client.go
@@ -188,21 +188,22 @@ func (c Client) WaitForEventFinished(id interface{}, entityType EntityType, acti
 	start := time.Now()
 	for {
 		filter, err := json.Marshal(map[string]interface{}{
-			// Entity is not really filtered, but is ignored by the API
+			// Entity is not filtered by the API
 			// Perhaps one day they will permit Entity ID/Type filtering.
 			// We'll have to verify these values manually, for now.
-			// "entity": map[string]interface{}{
+			//"entity": map[string]interface{}{
 			//	"id":   fmt.Sprintf("%v", id),
 			//	"type": entityType,
-			// },
+			//},
+
 			// Nor is action
-			// "action": action,
-			// Created is not really filtered, but ignored by the API
-			// Perhaps one day they will permit created filtering.
+			//"action": action,
+
+			// Created is not correctly filtered by the API
 			// We'll have to verify these values manually, for now.
-			"created": map[string]interface{}{
-				"+gte": minStart.Format(time.RFC3339),
-			},
+			//"created": map[string]interface{}{
+			//	"+gte": minStart.Format(time.RFC3339),
+			//},
 			"+order_by": "created",
 			"+order":    "desc",
 		})
@@ -215,6 +216,7 @@ func (c Client) WaitForEventFinished(id interface{}, entityType EntityType, acti
 
 		// If there are events for this instance + action, inspect them
 		for _, event := range events {
+			log.Println("waiting %ds for matching event:", timeoutSeconds, action, entityType, minStart)
 			if event.Action != action || event.Entity.Type != entityType || !event.Created.After(minStart) {
 				// Not the event we were looking for
 				continue

--- a/client.go
+++ b/client.go
@@ -72,6 +72,7 @@ func (c *Client) SetUserAgent(ua string) *Client {
 // R wraps resty's R method
 func (c *Client) R() *resty.Request {
 	return c.resty.R().
+		SetHeader("Content-Type", "application/json").
 		SetError(APIError{})
 }
 

--- a/domains.go
+++ b/domains.go
@@ -1,18 +1,112 @@
 package linodego
 
 import (
+	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/go-resty/resty"
 )
 
 // Domain represents a Domain object
 type Domain struct {
+	//	This Domain's unique ID
 	ID int
-	// UpdatedStr string `json:"updated"`
 
-	Updated *time.Time `json:"-"`
+	// The domain this Domain represents. These must be unique in our system; you cannot have two Domains representing the same domain.
+	Domain string
+
+	// If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave).
+	Type string // Enum:"master" "slave"
+
+	// Deprecated: The group this Domain belongs to. This is for display purposes only.
+	Group string
+
+	// Used to control whether this Domain is currently being rendered.
+	Status string // Enum:"disabled" "active" "edit_mode" "has_errors"
+
+	// A description for this Domain. This is for display purposes only.
+	Description string
+
+	// Start of Authority email address. This is required for master Domains.
+	SOAEmail string `json:"soa_email"`
+
+	// The interval, in seconds, at which a failed refresh should be retried.
+	// Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	RetrySec int `json:"retry_sec"`
+
+	// The IP addresses representing the master DNS for this Domain.
+	MasterIPs []string `json:"master_ips"`
+
+	// The list of IPs that may perform a zone transfer for this Domain. This is potentially dangerous, and should be set to an empty list unless you intend to use it.
+	AXfrIPs []string `json:"axfr_ips"`
+
+	// The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	ExpireSec int `json:"expire_sec"`
+
+	// The amount of time in seconds before this Domain should be refreshed. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	RefreshSec int `json:"refresh_sec"`
+
+	// "Time to Live" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	TTLSec int `json:"ttl_sec"`
+}
+
+type DomainCreateOptions DomainUpdateOptions
+
+type DomainUpdateOptions struct {
+	// The domain this Domain represents. These must be unique in our system; you cannot have two Domains representing the same domain.
+	Domain string `json:"domain,omitempty"`
+
+	// If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave).
+	// Enum:"master" "slave"
+	Type string `json:"type,omitempty"`
+
+	// Deprecated: The group this Domain belongs to. This is for display purposes only.
+	Group string `json:"group,omitempty"`
+
+	// Used to control whether this Domain is currently being rendered.
+	// Enum:"disabled" "active" "edit_mode" "has_errors"
+	Status string `json:"status,omitempty"`
+
+	// A description for this Domain. This is for display purposes only.
+	Description string `json:"description,omitempty"`
+
+	// Start of Authority email address. This is required for master Domains.
+	SOAEmail string `json:"soa_email,omitempty"`
+
+	// The interval, in seconds, at which a failed refresh should be retried.
+	// Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	RetrySec int `json:"retry_sec,omitempty"`
+
+	// The IP addresses representing the master DNS for this Domain.
+	MasterIPs []string `json:"master_ips,omitempty"`
+
+	// The list of IPs that may perform a zone transfer for this Domain. This is potentially dangerous, and should be set to an empty list unless you intend to use it.
+	AXfrIPs []string `json:"axfr_ips,omitempty"`
+
+	// The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	ExpireSec int `json:"expire_sec,omitempty"`
+
+	// The amount of time in seconds before this Domain should be refreshed. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	RefreshSec int `json:"refresh_sec,omitempty"`
+
+	// "Time to Live" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+	TTLSec int `json:"ttl_sec,omitempty"`
+}
+
+func (d Domain) GetUpdateOptions() (du DomainUpdateOptions) {
+	du.Domain = d.Domain
+	du.Type = d.Type
+	du.Group = d.Group
+	du.Status = d.Status
+	du.Description = d.Description
+	du.SOAEmail = d.SOAEmail
+	du.RetrySec = d.RetrySec
+	du.MasterIPs = d.MasterIPs
+	du.AXfrIPs = d.AXfrIPs
+	du.ExpireSec = d.ExpireSec
+	du.RefreshSec = d.RefreshSec
+	du.TTLSec = d.TTLSec
+	return
 }
 
 // DomainsPagedResponse represents a paginated Domain API response
@@ -60,7 +154,7 @@ func (v *Domain) fixDates() *Domain {
 	return v
 }
 
-// GetDomain gets the template with the provided ID
+// GetDomain gets the domain with the provided ID
 func (c *Client) GetDomain(id string) (*Domain, error) {
 	e, err := c.Domains.Endpoint()
 	if err != nil {
@@ -72,4 +166,71 @@ func (c *Client) GetDomain(id string) (*Domain, error) {
 		return nil, err
 	}
 	return r.Result().(*Domain).fixDates(), nil
+}
+
+// CreateDomain creates a Domain
+func (c *Client) CreateDomain(domain *DomainCreateOptions) (*Domain, error) {
+	var body string
+	e, err := c.Domains.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R().SetResult(&Domain{})
+
+	if bodyData, err := json.Marshal(domain); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Post(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Domain).fixDates(), nil
+}
+
+// UpdateDomain updates the Domain with the specified id
+func (c *Client) UpdateDomain(id int, domain DomainUpdateOptions) (*Domain, error) {
+	var body string
+	e, err := c.Domains.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R().SetResult(&Domain{})
+
+	if bodyData, err := json.Marshal(domain); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Put(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Domain).fixDates(), nil
+}
+
+// DeleteDomain deletes the Domain with the specified id
+func (c *Client) DeleteDomain(id int) error {
+	e, err := c.Domains.Endpoint()
+	if err != nil {
+		return err
+	}
+	e = fmt.Sprintf("%s/%d", e, id)
+
+	if _, err := coupleAPIErrors(c.R().Delete(e)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/example/main.go
+++ b/example/main.go
@@ -69,18 +69,23 @@ func moreExamples_authenticated() {
 		}
 
 		fmt.Println("## Created Instance\n", linode)
-		err = linodeClient.WaitForEventFinished(linode.ID, linodego.EntityLinode, linodego.ActionLinodeCreate, *linode.Created, 240)
+		event, err := linodeClient.WaitForEventFinished(linode.ID, linodego.EntityLinode, linodego.ActionLinodeCreate, *linode.Created, 240)
 		if err != nil {
 			log.Fatalf("* Failed to wait for Linode %d to finish creation: %s", linode.ID, err)
 		}
-
+		if err := linodeClient.MarkEventRead(event); err != nil {
+			log.Fatalln("* Failed to mark Linode create event seen", err)
+		}
 		disk, err := linodeClient.CreateInstanceDisk(linode.ID, linodego.InstanceDiskCreateOptions{Size: 50, Filesystem: "raw", Label: "linodego_disk"})
 		if err != nil {
 			log.Fatalln("* While creating disk:", err)
 		}
 
 		fmt.Println("### Created Disk\n", disk)
-		err = linodeClient.WaitForEventFinished(linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, disk.Created, 240)
+		event, err = linodeClient.WaitForEventFinished(linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, disk.Created, 240)
+		if err := linodeClient.MarkEventRead(event); err != nil {
+			log.Fatalln("* Failed to mark Disk create event seen", err)
+		}
 
 		// @TODO it is not sufficient that a disk was created. Which disk was it?
 		// Sounds like we'll need a WaitForEntityStatus function.

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -17,8 +17,8 @@ type InstanceDisk struct {
 	Status     string
 	Size       int
 	Filesystem string
-	Created    *time.Time `json:"-"`
-	Updated    *time.Time `json:"-"`
+	Created    time.Time `json:"-"`
+	Updated    time.Time `json:"-"`
 }
 
 // InstanceDisksPagedResponse represents a paginated InstanceDisk API response
@@ -83,8 +83,12 @@ func (c *Client) ListInstanceDisks(linodeID int, opts *ListOptions) ([]*Instance
 
 // fixDates converts JSON timestamps to Go time.Time values
 func (v *InstanceDisk) fixDates() *InstanceDisk {
-	v.Created, _ = parseDates(v.CreatedStr)
-	v.Updated, _ = parseDates(v.UpdatedStr)
+	if created, err := parseDates(v.CreatedStr); err == nil {
+		v.Created = *created
+	}
+	if updated, err := parseDates(v.UpdatedStr); err == nil {
+		v.Updated = *updated
+	}
 	return v
 }
 

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -131,7 +131,7 @@ func (c *Client) CreateInstanceDisk(linodeID int, createOpts InstanceDiskCreateO
 		return nil, err
 	}
 
-	return r.Result().(*InstanceDisk), nil
+	return r.Result().(*InstanceDisk).fixDates(), nil
 }
 
 // UpdateInstanceDisk creates a new InstanceDisk for the given Instance
@@ -160,7 +160,7 @@ func (c *Client) UpdateInstanceDisk(linodeID int, diskID int, updateOpts Instanc
 		return nil, err
 	}
 
-	return r.Result().(*InstanceDisk), nil
+	return r.Result().(*InstanceDisk).fixDates(), nil
 }
 
 // RenameInstanceDisk renames an InstanceDisk
@@ -196,7 +196,7 @@ func (c *Client) ResizeInstanceDisk(linodeID int, diskID int, size int) (*Instan
 	if err != nil {
 		return nil, err
 	}
-	return r.Result().(*InstanceDisk), nil
+	return r.Result().(*InstanceDisk).fixDates(), nil
 }
 
 // DeleteInstanceDisk deletes a Linode InstanceDisk

--- a/stackscripts.go
+++ b/stackscripts.go
@@ -1,13 +1,14 @@
 package linodego
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/go-resty/resty"
 )
 
-// Stackscript represents a linode stack script
+// Stackscript represents a Linode StackScript
 type Stackscript struct {
 	CreatedStr string `json:"created"`
 	UpdatedStr string `json:"updated"`
@@ -26,6 +27,39 @@ type Stackscript struct {
 	Script            string
 	UserDefinedFields *map[string]string
 	UserGravatarID    string
+}
+
+type StackscriptCreateOptions struct {
+	Label       string   `json:"label"`
+	Description string   `json:"description"`
+	Images      []string `json:"images"`
+	IsPublic    bool     `json:"is_public"`
+	RevNote     string   `json:"rev_note"`
+	Script      string   `json:"script"`
+}
+
+type StackscriptUpdateOptions StackscriptCreateOptions
+
+func (i Stackscript) GetCreateOptions() StackscriptCreateOptions {
+	return StackscriptCreateOptions{
+		Label:       i.Label,
+		Description: i.Description,
+		Images:      i.Images,
+		IsPublic:    i.IsPublic,
+		RevNote:     i.RevNote,
+		Script:      i.Script,
+	}
+}
+
+func (i Stackscript) GetUpdateOptions() StackscriptUpdateOptions {
+	return StackscriptUpdateOptions{
+		Label:       i.Label,
+		Description: i.Description,
+		Images:      i.Images,
+		IsPublic:    i.IsPublic,
+		RevNote:     i.RevNote,
+		Script:      i.Script,
+	}
 }
 
 // StackscriptsPagedResponse represents a paginated Stackscript API response
@@ -85,4 +119,73 @@ func (c *Client) GetStackscript(id int) (*Stackscript, error) {
 		return nil, err
 	}
 	return r.Result().(*Stackscript).fixDates(), nil
+}
+
+// CreateStackscript creates a StackScript
+func (c *Client) CreateStackscript(createOpts *StackscriptCreateOptions) (*Stackscript, error) {
+	var body string
+	e, err := c.StackScripts.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R().SetResult(&Stackscript{})
+
+	if bodyData, err := json.Marshal(createOpts); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Stackscript).fixDates(), nil
+}
+
+// UpdateStackscript updates the StackScript with the specified id
+func (c *Client) UpdateStackscript(id int, updateOpts StackscriptUpdateOptions) (*Stackscript, error) {
+	var body string
+	e, err := c.StackScripts.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s/%d", e, id)
+
+	req := c.R().SetResult(&Stackscript{})
+
+	if bodyData, err := json.Marshal(updateOpts); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Put(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Stackscript).fixDates(), nil
+}
+
+// DeleteStackscript deletes the StackScript with the specified id
+func (c *Client) DeleteStackscript(id int) error {
+	e, err := c.StackScripts.Endpoint()
+	if err != nil {
+		return err
+	}
+	e = fmt.Sprintf("%s/%d", e, id)
+
+	if _, err := coupleAPIErrors(c.R().Delete(e)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/template.go.example
+++ b/template.go.example
@@ -71,3 +71,72 @@ func (c *Client) GetTemplate(id string) (*Template, error) {
 	}
 	return r.Result().(*Template).fixDates(), nil
 }
+
+
+// CreateTemplate creates a Template
+func (c *Client) CreateTemplate(Template *TemplateCreateOptions) (*Template, error) {
+	var body string
+	e, err := c.Templates.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R().SetResult(&Template{})
+
+	if bodyData, err := json.Marshal(template); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Template).fixDates(), nil
+}
+
+// UpdateTemplate updates the Template with the specified id
+func (c *Client) UpdateTemplate(id int, updateOpts TemplateUpdateOptions) (*Template, error) {
+	var body string
+	e, err := c.Templates.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R().SetResult(&Template{})
+
+	if bodyData, err := json.Marshal(template); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Put(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Template).fixDates(), nil
+}
+
+// DeleteTemplate deletes the Template with the specified id
+func (c *Client) DeleteTemplate(id int) error {
+	e, err := c.Templates.Endpoint()
+	if err != nil {
+		return err
+	}
+	e = fmt.Sprintf("%s/%d", e, id)
+
+	if _, err := coupleAPIErrors(c.R().Delete(e)); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR:
- adds faux-enum strings for `EventAction`, event `EntityType`, and `EventStatus`
- adds some developers.linode.com copied field docs  
- adds Create, Update, Delete Domain (untested)
- adds Create, Update, Delete stubbing to template.go.example
- adds WaitForEventFinished which returns the Event when finished
- adds MarkEventRead and MarkEventsSeen 
- adds CreateStackscript, UpdateStackscript, DeleteStackscript
- example/main checks LINODE_SPEND and LINODE_DEBUG env vars to change behavior


I would like to find a way to offer `WaitForEventFinished` as a channel too..

I should probably split the Domain changes into another PR.