### PR TITLE
Fix AddInstanceIPAddress and UpdateDomain

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -201,6 +201,7 @@ func (c *Client) UpdateDomain(id int, domain DomainUpdateOptions) (*Domain, erro
 	if err != nil {
 		return nil, err
 	}
+	e = fmt.Sprintf("%s/%d", e, id)
 
 	req := c.R().SetResult(&Domain{})
 

--- a/example/main.go
+++ b/example/main.go
@@ -123,6 +123,41 @@ func moreExamples_authenticated() {
 			log.Fatalln("* Failed to mark Disk create event seen", err)
 		}
 
+		createOpts := linodego.InstanceConfigCreateOptions{
+			Devices: &linodego.InstanceConfigDeviceMap{
+				SDA: &linodego.InstanceConfigDevice{DiskID: disk.ID},
+			},
+			Kernel:     "linode/direct-disk",
+			Label:      "example config label",
+			RunLevel:   "default",
+			VirtMode:   "paravirt",
+			Comments:   "example config comment",
+			RootDevice: "/dev/sda",
+			Helpers: &linodego.InstanceConfigHelpers{
+				Network:    true,
+				ModulesDep: false,
+			},
+		}
+		config, err := linodeClient.CreateInstanceConfig(linode.ID, createOpts)
+		if err != nil {
+			log.Fatalln("* Failed to create Config", err)
+		}
+		fmt.Println("### Created Config:\n", config)
+		updateOpts := linodego.InstanceConfigUpdateOptions{
+			Comments: "updated example config comment",
+		}
+		config, err = linodeClient.UpdateInstanceConfig(linode.ID, config.ID, updateOpts)
+		if err != nil {
+			log.Fatalln("* Failed to update Config", err)
+		}
+		fmt.Println("### Updated Config:\n", config)
+
+		err = linodeClient.DeleteInstanceConfig(linode.ID, config.ID)
+		if err != nil {
+			log.Fatalln("* Failed to delete Config", err)
+		}
+		fmt.Println("### Deleted Config")
+
 		// @TODO it is not sufficient that a disk was created. Which disk was it?
 		// Sounds like we'll need a WaitForEntityStatus function.
 		if err != nil {

--- a/instance_configs.go
+++ b/instance_configs.go
@@ -28,19 +28,19 @@ type InstanceConfig struct {
 }
 
 type InstanceConfigDevice struct {
-	DiskID   int `json:"disk_id"`
-	VolumeID int `json:"volume_id"`
+	DiskID   int `json:"disk_id,omitempty"`
+	VolumeID int `json:"volume_id,omitempty"`
 }
 
 type InstanceConfigDeviceMap struct {
-	SDA *InstanceConfigDevice `json:"sda"`
-	SDB *InstanceConfigDevice `json:"sdb"`
-	SDC *InstanceConfigDevice `json:"sdc"`
-	SDD *InstanceConfigDevice `json:"sdd"`
-	SDE *InstanceConfigDevice `json:"sde"`
-	SDF *InstanceConfigDevice `json:"sdf"`
-	SDG *InstanceConfigDevice `json:"sdg"`
-	SDH *InstanceConfigDevice `json:"sdh"`
+	SDA *InstanceConfigDevice `json:"sda,omitempty"`
+	SDB *InstanceConfigDevice `json:"sdb,omitempty"`
+	SDC *InstanceConfigDevice `json:"sdc,omitempty"`
+	SDD *InstanceConfigDevice `json:"sdd,omitempty"`
+	SDE *InstanceConfigDevice `json:"sde,omitempty"`
+	SDF *InstanceConfigDevice `json:"sdf,omitempty"`
+	SDG *InstanceConfigDevice `json:"sdg,omitempty"`
+	SDH *InstanceConfigDevice `json:"sdh,omitempty"`
 }
 
 type InstanceConfigHelpers struct {
@@ -59,16 +59,16 @@ type InstanceConfigsPagedResponse struct {
 
 // InstanceConfigCreateOptions are InstanceConfig settings that can be used at creation
 type InstanceConfigCreateOptions struct {
-	Label       string                   `json:"label"`
-	Comments    string                   `json:"comments"`
-	Devices     *InstanceConfigDeviceMap `json:"devices"`
-	Helpers     *InstanceConfigHelpers   `json:"helpers"`
+	Label       string                   `json:"label,omitempty"`
+	Comments    string                   `json:"comments,omitempty"`
+	Devices     *InstanceConfigDeviceMap `json:"devices,omitempty"`
+	Helpers     *InstanceConfigHelpers   `json:"helpers,omitempty"`
 	MemoryLimit int                      `json:"memory_limit"`
-	Kernel      string                   `json:"kernel"`
+	Kernel      string                   `json:"kernel,omitempty"`
 	InitRD      int                      `json:"init_rd"`
-	RootDevice  string                   `json:"root_device"`
-	RunLevel    string                   `json:"run_level"`
-	VirtMode    string                   `json:"virt_mode"`
+	RootDevice  string                   `json:"root_device,omitempty"`
+	RunLevel    string                   `json:"run_level,omitempty"`
+	VirtMode    string                   `json:"virt_mode,omitempty"`
 }
 
 // InstanceConfigUpdateOptions are InstanceConfig settings that can be used in updates
@@ -173,10 +173,9 @@ func (c *Client) CreateInstanceConfig(linodeID int, createOpts InstanceConfigCre
 		return nil, err
 	}
 
-	r, err := req.
-		SetHeader("Content-Type", "application/json").
+	r, err := coupleAPIErrors(req.
 		SetBody(body).
-		Post(e)
+		Post(e))
 
 	if err != nil {
 		return nil, err
@@ -201,10 +200,9 @@ func (c *Client) UpdateInstanceConfig(linodeID int, configID int, updateOpts Ins
 		return nil, err
 	}
 
-	r, err := req.
-		SetHeader("Content-Type", "application/json").
+	r, err := coupleAPIErrors(req.
 		SetBody(body).
-		Put(e)
+		Put(e))
 
 	if err != nil {
 		return nil, err
@@ -219,13 +217,14 @@ func (c *Client) RenameInstanceConfig(linodeID int, configID int, label string) 
 }
 
 // DeleteInstanceConfig deletes a Linode InstanceConfig
-func (c *Client) DeleteInstanceConfig(id int) error {
-	e, err := c.InstanceConfigs.endpointWithID(id)
+func (c *Client) DeleteInstanceConfig(linodeID int, configID int) error {
+	e, err := c.InstanceConfigs.endpointWithID(linodeID)
 	if err != nil {
 		return err
 	}
+	e = fmt.Sprintf("%s/%d", e, configID)
 
-	if _, err = c.R().Delete(e); err != nil {
+	if _, err = coupleAPIErrors(c.R().Delete(e)); err != nil {
 		return err
 	}
 

--- a/instance_configs.go
+++ b/instance_configs.go
@@ -137,10 +137,10 @@ func (c *Client) ListInstanceConfigs(linodeID int, opts *ListOptions) ([]*Instan
 }
 
 // fixDates converts JSON timestamps to Go time.Time values
-func (v *InstanceConfig) fixDates() *InstanceConfig {
-	v.Created, _ = parseDates(v.CreatedStr)
-	v.Updated, _ = parseDates(v.UpdatedStr)
-	return v
+func (i *InstanceConfig) fixDates() *InstanceConfig {
+	i.Created, _ = parseDates(i.CreatedStr)
+	i.Updated, _ = parseDates(i.UpdatedStr)
+	return i
 }
 
 // GetInstanceConfig gets the template with the provided ID
@@ -182,7 +182,7 @@ func (c *Client) CreateInstanceConfig(linodeID int, createOpts InstanceConfigCre
 		return nil, err
 	}
 
-	return r.Result().(*InstanceConfig), nil
+	return r.Result().(*InstanceConfig).fixDates(), nil
 }
 
 // UpdateInstanceConfig update an InstanceConfig for the given Instance
@@ -210,7 +210,7 @@ func (c *Client) UpdateInstanceConfig(linodeID int, configID int, updateOpts Ins
 		return nil, err
 	}
 
-	return r.Result().(*InstanceConfig), nil
+	return r.Result().(*InstanceConfig).fixDates(), nil
 }
 
 // RenameInstanceConfig renames an InstanceConfig

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -79,7 +79,7 @@ func (c *Client) AddInstanceIPAddress(linodeID int, public bool) (*InstanceIP, e
 	instanceipRequest := struct {
 		Type   string `json:"type"`
 		Public bool   `json:"public"`
-	}{"ipv4", true}
+	}{"ipv4", public}
 
 	if bodyData, err := json.Marshal(instanceipRequest); err == nil {
 		body = string(bodyData)

--- a/template.go.example
+++ b/template.go.example
@@ -107,6 +107,7 @@ func (c *Client) UpdateTemplate(id int, updateOpts TemplateUpdateOptions) (*Temp
 	if err != nil {
 		return nil, err
 	}
+	e = fmt.Sprintf("%s/%d", e, id)
 
 	req := c.R().SetResult(&Template{})
 


### PR DESCRIPTION
The `public` param to `AddInstanceIPAddress` was being ignored.

`UpdateDomain` was `PUT`ting to `/domains/` instead of `/domains/123` 