### PR TITLE
add DeleteVolume, CreateVolume and supporting tests, types, and consts

### DIFF
--- a/API_SUPPORT.md
+++ b/API_SUPPORT.md
@@ -304,11 +304,11 @@
 
 - `/volumes`
   - [X] `GET`
-  - [ ] `POST`
+  - [X] `POST`
 - `/volumes/$id`
   - [X] `GET`
   - [ ] `POST`
-  - [ ] `DELETE`
+  - [X] `DELETE`
 - `/volumes/$id/attach`
   - [X] `POST`
 - `/volumes/$id/clone`

--- a/API_SUPPORT.md
+++ b/API_SUPPORT.md
@@ -307,7 +307,7 @@
   - [X] `POST`
 - `/volumes/$id`
   - [X] `GET`
-  - [ ] `POST`
+  - [X] `PUT`
   - [X] `DELETE`
 - `/volumes/$id/attach`
   - [X] `POST`

--- a/client.go
+++ b/client.go
@@ -219,6 +219,28 @@ func WaitForInstanceStatus(client *Client, instanceID int, status InstanceStatus
 	}
 }
 
+// WaitForVolumeStatus waits for the Volume to reach the desired state
+// before returning. It will timeout with an error after timeoutSeconds.
+func WaitForVolumeStatus(client *Client, volumeID int, status VolumeStatus, timeoutSeconds int) error {
+	start := time.Now()
+	for {
+		volume, err := client.GetVolume(volumeID)
+		if err != nil {
+			return err
+		}
+		complete := (volume.Status == status)
+
+		if complete {
+			return nil
+		}
+
+		time.Sleep(1 * time.Second)
+		if time.Since(start) > time.Duration(timeoutSeconds)*time.Second {
+			return fmt.Errorf("Instance %d didn't reach '%s' status in %d seconds", volumeID, status, timeoutSeconds)
+		}
+	}
+}
+
 // WaitForEventFinished waits for an entity action to reach the 'finished' state
 // before returning. It will timeout with an error after timeoutSeconds.
 // If the event indicates a failure both the failed event and the error will be returned.

--- a/client_test.go
+++ b/client_test.go
@@ -15,6 +15,7 @@ var debugAPI = false
 var validTestAPIKey = "NOTANAPIKEY"
 
 var TestInstanceID int
+var TestVolumeID int
 
 func init() {
 	if apiToken, ok := os.LookupEnv("LINODE_TOKEN"); ok {
@@ -39,6 +40,12 @@ func init() {
 		TestInstanceID, _ = strconv.Atoi(apiTestInstance)
 		log.Printf("[INFO] LINODE_TEST_INSTANCE %d will be examined for tests", TestInstanceID)
 	}
+
+	if apiTestVolume, ok := os.LookupEnv("LINODE_TEST_VOLUME"); ok {
+		TestVolumeID, _ = strconv.Atoi(apiTestVolume)
+		log.Printf("[INFO] LINODE_TEST_VOLUME %d will be examined for tests", TestVolumeID)
+	}
+
 }
 
 // testRecorder returns a go-vcr recorder and an associated function that the caller must defer

--- a/fixtures/TestCreateVolume.yaml
+++ b/fixtures/TestCreateVolume.yaml
@@ -1,0 +1,145 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"label":"linodego-test-volume","region":"us-west"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 1.0.0 https://github.com/chiefy/linodego
+    url: https://api.linode.com/v4/volumes
+    method: POST
+  response:
+    body: '{"label": "linodego-test-volume", "filesystem_path": "/dev/disk/by-id/scsi-0Linode_Volume_linodego-test-volume",
+      "size": 20, "created": "2018-01-02T03:04:05", "region": "us-west", "linode_id":
+      null, "id": 9280, "updated": "2018-01-02T03:04:05", "status": "creating"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "266"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Jul 2018 04:29:07 GMT
+      Retry-After:
+      - "119"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - volumes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "399"
+      X-Ratelimit-Reset:
+      - "1531456267"
+      X-Spec-Version:
+      - 4.0.3
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 1.0.0 https://github.com/chiefy/linodego
+    url: https://api.linode.com/v4/volumes/9280
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Jul 2018 04:29:08 GMT
+      Retry-After:
+      - "118"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - volumes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "399"
+      X-Ratelimit-Reset:
+      - "1531456267"
+      X-Spec-Version:
+      - 4.0.3
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fixtures/TestCreateVolume.yaml
+++ b/fixtures/TestCreateVolume.yaml
@@ -18,7 +18,7 @@ interactions:
   response:
     body: '{"label": "linodego-test-volume", "filesystem_path": "/dev/disk/by-id/scsi-0Linode_Volume_linodego-test-volume",
       "size": 20, "created": "2018-01-02T03:04:05", "region": "us-west", "linode_id":
-      null, "id": 9280, "updated": "2018-01-02T03:04:05", "status": "creating"}'
+      null, "id": 9354, "updated": "2018-01-02T03:04:05", "status": "creating"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Jul 2018 04:29:07 GMT
+      - Sun, 15 Jul 2018 16:08:46 GMT
       Retry-After:
       - "119"
       Server:
@@ -65,7 +65,80 @@ interactions:
       X-Ratelimit-Remaining:
       - "399"
       X-Ratelimit-Reset:
-      - "1531456267"
+      - "1531671046"
+      X-Spec-Version:
+      - 4.0.3
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"label":"test-volume-renamed"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 1.0.0 https://github.com/chiefy/linodego
+    url: https://api.linode.com/v4/volumes/9354
+    method: PUT
+  response:
+    body: '{"status": "creating", "linode_id": null, "label": "test-volume-renamed",
+      "size": 20, "id": 9354, "created": "2018-01-02T03:04:05", "filesystem_path":
+      "/dev/disk/by-id/scsi-0Linode_Volume_test-volume-renamed", "updated": "2018-01-02T03:04:05",
+      "region": "us-west"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 15 Jul 2018 16:08:46 GMT
+      Retry-After:
+      - "119"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - volumes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "399"
+      X-Ratelimit-Reset:
+      - "1531671046"
       X-Spec-Version:
       - 4.0.3
       X-Xss-Protection:
@@ -85,7 +158,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego 1.0.0 https://github.com/chiefy/linodego
-    url: https://api.linode.com/v4/volumes/9280
+    url: https://api.linode.com/v4/volumes/9354
     method: DELETE
   response:
     body: '{}'
@@ -111,9 +184,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Jul 2018 04:29:08 GMT
+      - Sun, 15 Jul 2018 16:08:47 GMT
       Retry-After:
-      - "118"
+      - "85"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -133,9 +206,9 @@ interactions:
       X-Ratelimit-Limit:
       - "400"
       X-Ratelimit-Remaining:
-      - "399"
+      - "398"
       X-Ratelimit-Reset:
-      - "1531456267"
+      - "1531671013"
       X-Spec-Version:
       - 4.0.3
       X-Xss-Protection:

--- a/fixtures/TestGetVolume.yaml
+++ b/fixtures/TestGetVolume.yaml
@@ -13,47 +13,65 @@ interactions:
       - application/json
       User-Agent:
       - linodego 1.0.0 https://github.com/chiefy/linodego
-    url: https://api.linode.com/v4/volumes/7568
+    url: https://api.linode.com/v4/volumes/6574839201
     method: GET
   response:
-    body: '{"errors": [{"reason": "Not found"}]}'
+    body: '{"updated": "2018-01-02T03:04:05", "linode_id": null, "created": "2018-01-02T03:04:05",
+      "size": 11, "filesystem_path": "/dev/disk/by-id/scsi-0Linode_Volume_test-volume",
+      "status": "active", "region": "us-east", "label": "test-volume", "id": 6574839201}'
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Access-Control-Allow-Headers:
       - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
       Access-Control-Allow-Methods:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
       Connection:
       - keep-alive
       Content-Length:
-      - "37"
+      - "246"
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 03 Jul 2018 01:38:53 GMT
+      - Fri, 13 Jul 2018 04:53:18 GMT
       Retry-After:
-      - "23"
+      - "119"
       Server:
       - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
+      - Authorization, X-Filter
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - volumes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
       X-Frame-Options:
+      - DENY
       - DENY
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
       - "400"
       X-Ratelimit-Remaining:
-      - "395"
+      - "399"
       X-Ratelimit-Reset:
-      - "1530581957"
+      - "1531457718"
       X-Spec-Version:
-      - 4.0.2
-    status: 404 NOT FOUND
-    code: 404
+      - 4.0.3
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
     duration: ""

--- a/volumes.go
+++ b/volumes.go
@@ -167,6 +167,29 @@ func (c *Client) CreateVolume(createOpts VolumeCreateOptions) (*Volume, error) {
 	return resp.Result().(*Volume).fixDates(), nil
 }
 
+// RenameVolume renames the label of a Linode volume
+// There is no UpdateVolume because the label is the only alterable field.
+func (c *Client) RenameVolume(id int, label string) (*Volume, error) {
+	body, _ := json.Marshal(map[string]string{"label": label})
+
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return nil, NewError(err)
+	}
+	e = fmt.Sprintf("%s/%d", e, id)
+
+	resp, err := coupleAPIErrors(c.R().
+		SetResult(&Volume{}).
+		SetBody(body).
+		Put(e))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Result().(*Volume).fixDates(), nil
+}
+
 // CloneVolume clones a Linode volume
 func (c *Client) CloneVolume(id int, label string) (*Volume, error) {
 	body := fmt.Sprintf("{\"label\":\"%s\"}", label)

--- a/volumes.go
+++ b/volumes.go
@@ -8,6 +8,29 @@ import (
 	"github.com/go-resty/resty"
 )
 
+// VolumeStatus indicates the status of the Volume
+type VolumeStatus string
+
+const (
+	// VolumeCreating indicates the Volume is being created and is not yet available for use
+	VolumeCreating VolumeStatus = "creating"
+
+	// VolumeActive indicates the Volume is online and available for use
+	VolumeActive VolumeStatus = "active"
+
+	// VolumeResizing indicates the Volume is in the process of upgrading its current capacity
+	VolumeResizing VolumeStatus = "resizing"
+
+	// VolumeDeleting indicates the Volume is being deleted and is unavailable for use
+	VolumeDeleting VolumeStatus = "deleting"
+
+	// VolumeDeleted indicates the Volume has been deleted
+	VolumeDeleted VolumeStatus = "deleted"
+
+	// VolumeContactSupport indicates there is a problem with the Volume. A support ticket must be opened to resolve the issue
+	VolumeContactSupport VolumeStatus = "contact_support"
+)
+
 // Volume represents a linode volume object
 type Volume struct {
 	CreatedStr string `json:"created"`
@@ -15,7 +38,7 @@ type Volume struct {
 
 	ID       int
 	Label    string
-	Status   string
+	Status   VolumeStatus
 	Region   string
 	Size     int
 	LinodeID int        `json:"linode_id"`
@@ -23,12 +46,19 @@ type Volume struct {
 	Updated  *time.Time `json:"-"`
 }
 
+type VolumeCreateOptions struct {
+	Label    string `json:"label,omitempty"`
+	Region   string `json:"region,omitempty"`
+	LinodeID int    `json:"linode_id,omitempty"`
+	ConfigID int    `json:"config_id,omitempty"`
+}
+
 type VolumeAttachOptions struct {
 	LinodeID int
 	ConfigID int
 }
 
-// LinodeVolumesPagedResponse represents a linode API response for listing of volumes
+// VolumesPagedResponse represents a linode API response for listing of volumes
 type VolumesPagedResponse struct {
 	*PageOptions
 	Data []*Volume
@@ -80,7 +110,7 @@ func (c *Client) GetVolume(id int) (*Volume, error) {
 		return nil, err
 	}
 	e = fmt.Sprintf("%s/%d", e, id)
-	r, err := c.R().SetResult(&Volume{}).Get(e)
+	r, err := coupleAPIErrors(c.R().SetResult(&Volume{}).Get(e))
 	if err != nil {
 		return nil, err
 	}
@@ -93,39 +123,41 @@ func (c *Client) AttachVolume(id int, options *VolumeAttachOptions) (bool, error
 	if bodyData, err := json.Marshal(options); err == nil {
 		body = string(bodyData)
 	} else {
-		return false, err
+		return false, NewError(err)
 	}
 
 	e, err := c.Volumes.Endpoint()
 	if err != nil {
-		return false, err
+		return false, NewError(err)
 	}
 
 	e = fmt.Sprintf("%s/%d/attach", e, id)
-	resp, err := c.R().
+	resp, err := coupleAPIErrors(c.R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(body).
-		Post(e)
+		Post(e))
 
 	return settleBoolResponseOrError(resp, err)
 }
 
-// CloneVolume clones a Linode instance
-func (c *Client) CloneVolume(id int, label string) (*Volume, error) {
-	body := fmt.Sprintf("{\"label\":\"%s\"}", label)
+// CreateVolume creates a Linode Volume
+func (c *Client) CreateVolume(createOpts VolumeCreateOptions) (*Volume, error) {
+	body := ""
+	if bodyData, err := json.Marshal(createOpts); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
 
 	e, err := c.Volumes.Endpoint()
 	if err != nil {
-		return nil, err
+		return nil, NewError(err)
 	}
-	e = fmt.Sprintf("%s/%d/clone", e, id)
 
-	req := c.R().SetResult(&Volume{})
-
-	resp, err := req.
-		SetHeader("Content-Type", "application/json").
+	resp, err := coupleAPIErrors(c.R().
+		SetResult(&Volume{}).
 		SetBody(body).
-		Post(e)
+		Post(e))
 
 	if err != nil {
 		return nil, err
@@ -134,21 +166,42 @@ func (c *Client) CloneVolume(id int, label string) (*Volume, error) {
 	return resp.Result().(*Volume).fixDates(), nil
 }
 
-// DetachVolume detaches a Linode instance
+// CloneVolume clones a Linode volume
+func (c *Client) CloneVolume(id int, label string) (*Volume, error) {
+	body := fmt.Sprintf("{\"label\":\"%s\"}", label)
+
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return nil, NewError(err)
+	}
+	e = fmt.Sprintf("%s/%d/clone", e, id)
+
+	resp, err := coupleAPIErrors(c.R().
+		SetResult(&Volume{}).
+		SetBody(body).
+		Post(e))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Result().(*Volume).fixDates(), nil
+}
+
+// DetachVolume detaches a Linode volume
 func (c *Client) DetachVolume(id int) (bool, error) {
 	body := ""
 
 	e, err := c.Volumes.Endpoint()
 	if err != nil {
-		return false, err
+		return false, NewError(err)
 	}
 
 	e = fmt.Sprintf("%s/%d/detach", e, id)
 
-	resp, err := c.R().
-		SetHeader("Content-Type", "application/json").
+	resp, err := coupleAPIErrors(c.R().
 		SetBody(body).
-		Post(e)
+		Post(e))
 
 	return settleBoolResponseOrError(resp, err)
 }
@@ -159,14 +212,28 @@ func (c *Client) ResizeVolume(id int, size int) (bool, error) {
 
 	e, err := c.Volumes.Endpoint()
 	if err != nil {
-		return false, err
+		return false, NewError(err)
 	}
 	e = fmt.Sprintf("%s/%d/resize", e, id)
 
-	resp, err := c.R().
-		SetHeader("Content-Type", "application/json").
+	resp, err := coupleAPIErrors(c.R().
 		SetBody(body).
-		Post(e)
+		Post(e))
 
 	return settleBoolResponseOrError(resp, err)
+}
+
+// DeleteVolume deletes the Volume with the specified id
+func (c *Client) DeleteVolume(id int) error {
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return err
+	}
+	e = fmt.Sprintf("%s/%d", e, id)
+
+	if _, err := coupleAPIErrors(c.R().Delete(e)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/volumes.go
+++ b/volumes.go
@@ -51,6 +51,8 @@ type VolumeCreateOptions struct {
 	Region   string `json:"region,omitempty"`
 	LinodeID int    `json:"linode_id,omitempty"`
 	ConfigID int    `json:"config_id,omitempty"`
+	// The Volume's size, in GiB. Minimum size is 10GiB, maximum size is 10240GiB. A "0" value will result in the default size.
+	Size int `json:"size,omitempty"`
 }
 
 type VolumeAttachOptions struct {

--- a/volumes.go
+++ b/volumes.go
@@ -21,12 +21,6 @@ const (
 	// VolumeResizing indicates the Volume is in the process of upgrading its current capacity
 	VolumeResizing VolumeStatus = "resizing"
 
-	// VolumeDeleting indicates the Volume is being deleted and is unavailable for use
-	VolumeDeleting VolumeStatus = "deleting"
-
-	// VolumeDeleted indicates the Volume has been deleted
-	VolumeDeleted VolumeStatus = "deleted"
-
 	// VolumeContactSupport indicates there is a problem with the Volume. A support ticket must be opened to resolve the issue
 	VolumeContactSupport VolumeStatus = "contact_support"
 )
@@ -36,14 +30,15 @@ type Volume struct {
 	CreatedStr string `json:"created"`
 	UpdatedStr string `json:"updated"`
 
-	ID       int
-	Label    string
-	Status   VolumeStatus
-	Region   string
-	Size     int
-	LinodeID int        `json:"linode_id"`
-	Created  *time.Time `json:"-"`
-	Updated  *time.Time `json:"-"`
+	ID             int
+	Label          string
+	Status         VolumeStatus
+	Region         string
+	Size           int
+	LinodeID       *int      `json:"linode_id"`
+	FilesystemPath string    `json:"filesystem_path"`
+	Created        time.Time `json:"-"`
+	Updated        time.Time `json:"-"`
 }
 
 type VolumeCreateOptions struct {
@@ -100,8 +95,12 @@ func (c *Client) ListVolumes(opts *ListOptions) ([]*Volume, error) {
 
 // fixDates converts JSON timestamps to Go time.Time values
 func (v *Volume) fixDates() *Volume {
-	v.Created, _ = parseDates(v.CreatedStr)
-	v.Updated, _ = parseDates(v.UpdatedStr)
+	if parsed, err := parseDates(v.CreatedStr); err != nil {
+		v.Created = *parsed
+	}
+	if parsed, err := parseDates(v.UpdatedStr); err != nil {
+		v.Updated = *parsed
+	}
 	return v
 }
 

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -2,9 +2,33 @@ package linodego_test
 
 import (
 	"testing"
+
+	"github.com/chiefy/linodego"
 )
 
-const TestVolumeID = 7568
+func TestCreateVolume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+	client, teardown := createTestClient(t, "fixtures/TestCreateVolume")
+	defer teardown()
+
+	createOpts := linodego.VolumeCreateOptions{
+		Label:  "linodego-test-volume",
+		Region: "us-west",
+	}
+	volume, err := client.CreateVolume(createOpts)
+	if err != nil {
+		t.Errorf("Error listing volumes, expected struct, got error %v", err)
+	}
+	if volume.ID == 0 {
+		t.Errorf("Expected a volumes id, but got 0")
+	}
+
+	if err := client.DeleteVolume(volume.ID); err != nil {
+		t.Errorf("Expected to delete a volume, but got %v", err)
+	}
+}
 
 func TestListVolumes(t *testing.T) {
 	if testing.Short() {

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -30,6 +30,19 @@ func TestCreateVolume(t *testing.T) {
 	}
 }
 
+func TestRenameVolume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode.")
+	}
+	client, volume, teardown, err := setupVolume(t, "fixtures/TestCreateVolume")
+	defer teardown()
+
+	volume, err = client.RenameVolume(volume.ID, "test-volume-renamed")
+	if err != nil {
+		t.Errorf("Error renaming volume, %s", err)
+	}
+}
+
 func TestListVolumes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
@@ -57,4 +70,26 @@ func TestGetVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting volume %d, expected *LinodeVolume, got error %v", TestVolumeID, err)
 	}
+}
+
+func setupVolume(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego.Volume, func(), error) {
+	t.Helper()
+	var fixtureTeardown func()
+	client, fixtureTeardown := createTestClient(t, fixturesYaml)
+	createOpts := linodego.VolumeCreateOptions{
+		Label:  "linodego-test-volume",
+		Region: "us-west",
+	}
+	volume, err := client.CreateVolume(createOpts)
+	if err != nil {
+		t.Errorf("Error listing volumes, expected struct, got error %v", err)
+	}
+
+	teardown := func() {
+		if err := client.DeleteVolume(volume.ID); err != nil {
+			t.Errorf("Expected to delete a volume, but got %v", err)
+		}
+		fixtureTeardown()
+	}
+	return client, volume, teardown, err
 }


### PR DESCRIPTION
Adds functions and types necessary for handling Linode Volumes:
- Fixes error handling for 404'd volume requests
- Fixes LinodeID to *int in Volume types because it is nullable in the API response
- CreateVolume
- DeleteVolume
- RenameVolume
- WaitForVolumeStatus 
- VolumeCreateOptions
- VolumeStatus: VolumeCreating, VolumeActive, VolumeResizing, VolumeContactSupport