### PR TITLE
fix: go-resty doesnt pass errors when content-type is not set

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	resty     *resty.Client
 	userAgent string
 	resources map[string]*Resource
+	debug     bool
 
 	Images                *Resource
 	InstanceDisks         *Resource
@@ -72,9 +73,10 @@ type Client struct {
 
 func init() {
 	// Wether or not we will enable Resty debugging output
-	if envDebug, ok := os.LookupEnv("LINODE_DEBUG"); ok {
-		if apiDebug, err := strconv.ParseBool(envDebug); err == nil {
-			log.Println("[INFO] LINODE_DEBUG being set to", apiDebug)
+	if apiDebug, ok := os.LookupEnv("LINODE_DEBUG"); ok {
+		if parsed, err := strconv.ParseBool(apiDebug); err == nil {
+			envDebug = parsed
+			log.Println("[INFO] LINODE_DEBUG being set to", envDebug)
 		} else {
 			log.Println("[WARN] LINODE_DEBUG should be an integer, 0 or 1")
 		}
@@ -93,6 +95,7 @@ func (c *Client) SetUserAgent(ua string) *Client {
 // R wraps resty's R method
 func (c *Client) R(ctx context.Context) *resty.Request {
 	return c.resty.R().
+		ExpectContentType("application/json").
 		SetHeader("Content-Type", "application/json").
 		SetContext(ctx).
 		SetError(APIError{})
@@ -100,6 +103,7 @@ func (c *Client) R(ctx context.Context) *resty.Request {
 
 // SetDebug sets the debug on resty's client
 func (c *Client) SetDebug(debug bool) *Client {
+	c.debug = debug
 	c.resty.SetDebug(debug)
 	return c
 }
@@ -191,7 +195,7 @@ func NewClient(hc *http.Client) (client Client) {
 	return
 }
 
-// waitForInstanceStatus waits for the Linode instance to reach the desired state
+// WaitForInstanceStatus waits for the Linode instance to reach the desired state
 // before returning. It will timeout with an error after timeoutSeconds.
 func WaitForInstanceStatus(ctx context.Context, client *Client, instanceID int, status InstanceStatus, timeoutSeconds int) error {
 	start := time.Now()

--- a/client_test.go
+++ b/client_test.go
@@ -25,7 +25,12 @@ func init() {
 	}
 
 	if apiDebug, ok := os.LookupEnv("LINODE_DEBUG"); ok {
-		debugAPI, _ = strconv.ParseBool(apiDebug)
+		if parsed, err := strconv.ParseBool(apiDebug); err == nil {
+			debugAPI = parsed
+			log.Println("[INFO] LINODE_DEBUG being set to", debugAPI)
+		} else {
+			log.Println("[WARN] LINODE_DEBUG should be an integer, 0 or 1")
+		}
 	}
 
 	if envFixtureMode, ok := os.LookupEnv("LINODE_FIXTURE_MODE"); ok {
@@ -106,6 +111,7 @@ func createTestClient(t *testing.T, fixturesYaml string) (*Client, func()) {
 
 	c = NewClient(oc)
 	c.SetDebug(debugAPI)
+
 	return &c, recordStopper
 }
 

--- a/fixtures/TestListTypes_429.yaml
+++ b/fixtures/TestListTypes_429.yaml
@@ -1,0 +1,31 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.0.1 https://github.com/chiefy/linodego
+    url: https://api.linode.com/v4/linode/types
+    method: GET
+  response:
+    body: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "0"
+      Date:
+      - Tue, 03 Jul 2018 01:38:52 GMT
+      Server:
+      - nginx
+    status: 429 429
+    code: 429
+    duration: ""

--- a/types_test.go
+++ b/types_test.go
@@ -37,6 +37,7 @@ func TestGetType_found(t *testing.T) {
 		t.Errorf("Expected a specific image, but got a different one %v", i)
 	}
 }
+
 func TestListTypes(t *testing.T) {
 	client, teardown := createTestClient(t, "fixtures/TestListTypes")
 	defer teardown()
@@ -47,5 +48,15 @@ func TestListTypes(t *testing.T) {
 	}
 	if len(i) == 0 {
 		t.Errorf("Expected a list of images, but got none %v", i)
+	}
+}
+
+func TestListTypes_429(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestListTypes_429")
+	defer teardown()
+
+	_, err := client.ListTypes(context.Background(), nil)
+	if err == nil {
+		t.Errorf("Error listing images, expected error")
 	}
 }


### PR DESCRIPTION
Go-Resty's ParseResponseBody is not prepared to handle empty responses that the Linode API returns in some 429 cases:

```
HTTP/1.1 429 429
Connection: keep-alive
Date: Mon, 30 Jul 2018 18:16:20 GMT
Server: nginx
Content-Length: 0
```

https://github.com/go-resty/resty/blob/master/middleware.go#L266-L292

https://github.com/go-resty/resty/pull/95 addressed this with a fallback content type via `ExpectContentType`.