### PR TITLE
consistent pointer use in Create/Update calls

### DIFF
--- a/API_SUPPORT.md
+++ b/API_SUPPORT.md
@@ -20,7 +20,7 @@
 - `/linode/instances/$id/rebuild`
   - [X] `POST`
 - `/linode/instances/$id/rescue`
-  - [ ] `POST`
+  - [X] `POST`
 - `/linode/instances/$id/resize`
   - [x] `POST`
 - `/linode/instances/$id/shutdown`
@@ -60,8 +60,6 @@
   - [X] `PUT`
   - [X] `POST`
   - [X] `DELETE`
-- `/linode/instances/$id/disks/$id/imagize`
-  - [ ] `POST`
 - `/linode/instances/$id/disks/$id/password`
   - [ ] `POST`
 - `/linode/instances/$id/disks/$id/resize`
@@ -123,11 +121,11 @@
   - [ ] `POST`
 - `/domains/$id/records`
   - [X] `GET`
-  - [ ] `POST`
+  - [X] `POST`
 - `/domains/$id/records/$id`
   - [X] `GET`
-  - [ ] `PUT`
-  - [ ] `DELETE`
+  - [X] `PUT`
+  - [X] `DELETE`
 
 ## Longview
 
@@ -297,8 +295,9 @@
   - [x] `GET`
 - `/images/$id`
   - [x] `GET`
-  - [ ] `PUT`
-  - [ ] `DELETE`
+  - [X] `POST`
+  - [X] `PUT`
+  - [X] `DELETE`
 
 ## Volumes
 

--- a/domain_records.go
+++ b/domain_records.go
@@ -150,7 +150,7 @@ func (c *Client) GetDomainRecord(ctx context.Context, domainID int, id int) (*Do
 }
 
 // CreateDomainRecord creates a DomainRecord
-func (c *Client) CreateDomainRecord(ctx context.Context, domainID int, domainrecord *DomainRecordCreateOptions) (*DomainRecord, error) {
+func (c *Client) CreateDomainRecord(ctx context.Context, domainID int, domainrecord DomainRecordCreateOptions) (*DomainRecord, error) {
 	var body string
 	e, err := c.DomainRecords.endpointWithID(domainID)
 	if err != nil {

--- a/domain_records_test.go
+++ b/domain_records_test.go
@@ -122,7 +122,7 @@ func setupDomainRecord(t *testing.T, fixturesYaml string) (*linodego.Client, *li
 	}
 
 	createOpts := testDomainRecordCreateOpts
-	record, err := client.CreateDomainRecord(context.Background(), domain.ID, &createOpts)
+	record, err := client.CreateDomainRecord(context.Background(), domain.ID, createOpts)
 	if err != nil {
 		t.Errorf("Error creating domain record, got error %v", err)
 	}

--- a/domains.go
+++ b/domains.go
@@ -220,7 +220,7 @@ func (c *Client) GetDomain(ctx context.Context, id int) (*Domain, error) {
 }
 
 // CreateDomain creates a Domain
-func (c *Client) CreateDomain(ctx context.Context, domain *DomainCreateOptions) (*Domain, error) {
+func (c *Client) CreateDomain(ctx context.Context, domain DomainCreateOptions) (*Domain, error) {
 	var body string
 	e, err := c.Domains.Endpoint()
 	if err != nil {

--- a/domains_test.go
+++ b/domains_test.go
@@ -82,7 +82,7 @@ func setupDomain(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego
 	var fixtureTeardown func()
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 	createOpts := testDomainCreateOpts
-	domain, err := client.CreateDomain(context.Background(), &createOpts)
+	domain, err := client.CreateDomain(context.Background(), createOpts)
 	if err != nil {
 		t.Errorf("Error listing domains, expected struct, got error %v", err)
 	}

--- a/example_integration_test.go
+++ b/example_integration_test.go
@@ -66,11 +66,11 @@ func Example() {
 	fmt.Println("### Error:", err)
 
 	if spendMoney {
-		linode, err = linodeClient.CreateInstance(context.Background(), &linodego.InstanceCreateOptions{Region: "us-central", Type: "g5-nanode-1"})
+		linode, err = linodeClient.CreateInstance(context.Background(), linodego.InstanceCreateOptions{Region: "us-central", Type: "g5-nanode-1"})
 		if err != nil {
 			log.Fatalln("* While creating instance: ", err)
 		}
-		linode, err = linodeClient.UpdateInstance(context.Background(), linode.ID, &linodego.InstanceUpdateOptions{Label: linode.Label + "-renamed"})
+		linode, err = linodeClient.UpdateInstance(context.Background(), linode.ID, linodego.InstanceUpdateOptions{Label: linode.Label + "-renamed"})
 		if err != nil {
 			log.Fatalln("* While renaming instance: ", err)
 		}

--- a/example_nodebalancers_test.go
+++ b/example_nodebalancers_test.go
@@ -21,7 +21,7 @@ func ExampleClient_CreateNodeBalancer() {
 	}
 
 	createOpts := nb.GetCreateOptions()
-	nb, err := linodeClient.CreateNodeBalancer(context.Background(), &createOpts)
+	nb, err := linodeClient.CreateNodeBalancer(context.Background(), createOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func ExampleClient_CreateNodeBalancerConfig() {
 
 	fmt.Println("## NodeBalancer create")
 	clientConnThrottle := 20
-	nb, err := linodeClient.CreateNodeBalancer(context.Background(), &linodego.NodeBalancerCreateOptions{
+	nb, err := linodeClient.CreateNodeBalancer(context.Background(), linodego.NodeBalancerCreateOptions{
 		ClientConnThrottle: &clientConnThrottle,
 		Region:             "us-east",
 	})
@@ -79,7 +79,7 @@ func ExampleClient_CreateNodeBalancerConfig() {
 			CipherSuite:   linodego.CipherRecommended,
 		*/
 	}
-	nbc, err := linodeClient.CreateNodeBalancerConfig(context.Background(), nb.ID, &createOpts)
+	nbc, err := linodeClient.CreateNodeBalancerConfig(context.Background(), nb.ID, createOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func ExampleClient_CreateNodeBalancerNode() {
 
 	fmt.Println("## NodeBalancer create")
 	clientConnThrottle := 20
-	nb, err := linodeClient.CreateNodeBalancer(context.Background(), &linodego.NodeBalancerCreateOptions{
+	nb, err := linodeClient.CreateNodeBalancer(context.Background(), linodego.NodeBalancerCreateOptions{
 		ClientConnThrottle: &clientConnThrottle,
 		Region:             "us-east",
 	})
@@ -143,7 +143,7 @@ func ExampleClient_CreateNodeBalancerNode() {
 
 	fmt.Println("## NodeBalancer Config create")
 
-	nbc, err := linodeClient.CreateNodeBalancerConfig(context.Background(), nb.ID, &linodego.NodeBalancerConfigCreateOptions{
+	nbc, err := linodeClient.CreateNodeBalancerConfig(context.Background(), nb.ID, linodego.NodeBalancerConfigCreateOptions{
 		Port: 80,
 	})
 	if err != nil {
@@ -155,7 +155,7 @@ func ExampleClient_CreateNodeBalancerNode() {
 		Address: "192.168.129.255:80",
 		Label:   "192.168.129.255-80",
 	}
-	nbn, err := linodeClient.CreateNodeBalancerNode(context.Background(), nb.ID, nbc.ID, &createOpts)
+	nbn, err := linodeClient.CreateNodeBalancerNode(context.Background(), nb.ID, nbc.ID, createOpts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example_stackscripts_test.go
+++ b/example_stackscripts_test.go
@@ -30,7 +30,7 @@ func ExampleClient_CreateStackscript() {
 			stackscript.Label = "example stackscript " + time.Now().String()
 			stackscript.RevNote = "revision " + strconv.Itoa(rev)
 			stackscript.Script = "#!/bin/bash\n"
-			ss, err = linodeClient.CreateStackscript(context.Background(), &stackscript)
+			ss, err = linodeClient.CreateStackscript(context.Background(), stackscript)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/instances.go
+++ b/instances.go
@@ -180,7 +180,7 @@ func (c *Client) GetInstance(ctx context.Context, linodeID int) (*Instance, erro
 }
 
 // CreateInstance creates a Linode instance
-func (c *Client) CreateInstance(ctx context.Context, instance *InstanceCreateOptions) (*Instance, error) {
+func (c *Client) CreateInstance(ctx context.Context, instance InstanceCreateOptions) (*Instance, error) {
 	var body string
 	e, err := c.Instances.Endpoint()
 	if err != nil {

--- a/instances.go
+++ b/instances.go
@@ -98,22 +98,25 @@ type InstanceCreateOptions struct {
 
 // InstanceUpdateOptions is an options struct used when Updating an Instance
 type InstanceUpdateOptions struct {
-	Label   string         `json:"label,omitempty"`
-	Group   string         `json:"group,omitempty"`
-	Backups InstanceBackup `json:"backups,omitempty"`
-	Alerts  InstanceAlert  `json:"alerts,omitempty"`
+	Label           string          `json:"label,omitempty"`
+	Group           string          `json:"group,omitempty"`
+	Backups         *InstanceBackup `json:"backups,omitempty"`
+	Alerts          *InstanceAlert  `json:"alerts,omitempty"`
+	WatchdogEnabled *bool           `json:"watchdog_enabled,omitempty"`
 }
 
-// InstanceCloneOptions is an options struct when sending a clone request to the API
+// InstanceCloneOptions is an options struct sent when Cloning an Instance
 type InstanceCloneOptions struct {
-	Region         string   `json:"region"`
-	Type           string   `json:"type"`
-	LinodeID       int      `json:"linode_id"`
-	Label          string   `json:"label"`
-	Group          string   `json:"group"`
-	BackupsEnabled bool     `json:"backups_enabled"`
-	Disks          []string `json:"disks"`
-	Configs        []string `json:"configs"`
+	Region string `json:"region,omitempty"`
+	Type   string `json:"type,omitempty"`
+
+	// LinodeID is an optional existing instance to use as the target of the clone
+	LinodeID       int    `json:"linode_id,omitempty"`
+	Label          string `json:"label,omitempty"`
+	Group          string `json:"group,omitempty"`
+	BackupsEnabled bool   `json:"backups_enabled"`
+	Disks          []int  `json:"disks,omitempty"`
+	Configs        []int  `json:"configs,omitempty"`
 }
 
 func (l *Instance) fixDates() *Instance {
@@ -203,7 +206,7 @@ func (c *Client) CreateInstance(ctx context.Context, instance *InstanceCreateOpt
 }
 
 // UpdateInstance creates a Linode instance
-func (c *Client) UpdateInstance(ctx context.Context, id int, instance *InstanceUpdateOptions) (*Instance, error) {
+func (c *Client) UpdateInstance(ctx context.Context, id int, instance InstanceUpdateOptions) (*Instance, error) {
 	var body string
 	e, err := c.Instances.Endpoint()
 	if err != nil {
@@ -231,7 +234,7 @@ func (c *Client) UpdateInstance(ctx context.Context, id int, instance *InstanceU
 
 // RenameInstance renames an Instance
 func (c *Client) RenameInstance(ctx context.Context, linodeID int, label string) (*Instance, error) {
-	return c.UpdateInstance(ctx, linodeID, &InstanceUpdateOptions{Label: label})
+	return c.UpdateInstance(ctx, linodeID, InstanceUpdateOptions{Label: label})
 }
 
 // DeleteInstance deletes a Linode instance
@@ -276,8 +279,8 @@ func (c *Client) BootInstance(ctx context.Context, id int, configID int) (bool, 
 	return settleBoolResponseOrError(r, err)
 }
 
-// CloneInstance clones a Linode instance
-func (c *Client) CloneInstance(ctx context.Context, id int, options *InstanceCloneOptions) (*Instance, error) {
+// CloneInstance clone an existing Instances Disks and Configuration profiles to another Linode Instance
+func (c *Client) CloneInstance(ctx context.Context, id int, options InstanceCloneOptions) (*Instance, error) {
 	var body string
 	e, err := c.Instances.Endpoint()
 	if err != nil {

--- a/instances_test.go
+++ b/instances_test.go
@@ -96,7 +96,7 @@ func setupInstance(t *testing.T, fixturesYaml string) (*linodego.Client, *linode
 		Region:   "us-west",
 		Type:     "g6-nanode-1",
 	}
-	instance, err := client.CreateInstance(context.Background(), &createOpts)
+	instance, err := client.CreateInstance(context.Background(), createOpts)
 	if err != nil {
 		t.Errorf("Error creating test Instance: %s", err)
 	}

--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -126,7 +126,7 @@ func (c *Client) GetNodeBalancer(ctx context.Context, id int) (*NodeBalancer, er
 }
 
 // CreateNodeBalancer creates a NodeBalancer
-func (c *Client) CreateNodeBalancer(ctx context.Context, nodebalancer *NodeBalancerCreateOptions) (*NodeBalancer, error) {
+func (c *Client) CreateNodeBalancer(ctx context.Context, nodebalancer NodeBalancerCreateOptions) (*NodeBalancer, error) {
 	var body string
 	e, err := c.NodeBalancers.Endpoint()
 	if err != nil {

--- a/nodebalancer_config_nodes.go
+++ b/nodebalancer_config_nodes.go
@@ -123,7 +123,7 @@ func (c *Client) GetNodeBalancerNode(ctx context.Context, nodebalancerID int, co
 }
 
 // CreateNodeBalancerNode creates a NodeBalancerNode
-func (c *Client) CreateNodeBalancerNode(ctx context.Context, nodebalancerID int, configID int, createOpts *NodeBalancerNodeCreateOptions) (*NodeBalancerNode, error) {
+func (c *Client) CreateNodeBalancerNode(ctx context.Context, nodebalancerID int, configID int, createOpts NodeBalancerNodeCreateOptions) (*NodeBalancerNode, error) {
 	var body string
 	e, err := c.NodeBalancerNodes.endpointWithID(nodebalancerID, configID)
 	if err != nil {

--- a/nodebalancer_config_nodes_test.go
+++ b/nodebalancer_config_nodes_test.go
@@ -132,7 +132,7 @@ func setupNodeBalancerNode(t *testing.T, fixturesYaml string) (*linodego.Client,
 	}
 
 	createOpts := testNodeBalancerNodeCreateOpts
-	node, err := client.CreateNodeBalancerNode(context.Background(), nodebalancer.ID, config.ID, &createOpts)
+	node, err := client.CreateNodeBalancerNode(context.Background(), nodebalancer.ID, config.ID, createOpts)
 	if err != nil {
 		t.Errorf("Error creating NodeBalancer Config Node, got error %v", err)
 	}

--- a/nodebalancer_configs.go
+++ b/nodebalancer_configs.go
@@ -192,7 +192,7 @@ func (c *Client) GetNodeBalancerConfig(ctx context.Context, nodebalancerID int, 
 }
 
 // CreateNodeBalancerConfig creates a NodeBalancerConfig
-func (c *Client) CreateNodeBalancerConfig(ctx context.Context, nodebalancerID int, nodebalancerConfig *NodeBalancerConfigCreateOptions) (*NodeBalancerConfig, error) {
+func (c *Client) CreateNodeBalancerConfig(ctx context.Context, nodebalancerID int, nodebalancerConfig NodeBalancerConfigCreateOptions) (*NodeBalancerConfig, error) {
 	var body string
 	e, err := c.NodeBalancerConfigs.endpointWithID(nodebalancerID)
 

--- a/nodebalancer_configs_test.go
+++ b/nodebalancer_configs_test.go
@@ -120,7 +120,7 @@ func setupNodeBalancerConfig(t *testing.T, fixturesYaml string) (*linodego.Clien
 	}
 
 	createOpts := testNodeBalancerConfigCreateOpts
-	config, err := client.CreateNodeBalancerConfig(context.Background(), nodebalancer.ID, &createOpts)
+	config, err := client.CreateNodeBalancerConfig(context.Background(), nodebalancer.ID, createOpts)
 	if err != nil {
 		t.Errorf("Error creating NodeBalancer Config, got error %v", err)
 	}

--- a/nodebalancers_test.go
+++ b/nodebalancers_test.go
@@ -91,7 +91,7 @@ func setupNodeBalancer(t *testing.T, fixturesYaml string) (*linodego.Client, *li
 	var fixtureTeardown func()
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 	createOpts := testNodeBalancerCreateOpts
-	nodebalancer, err := client.CreateNodeBalancer(context.Background(), &createOpts)
+	nodebalancer, err := client.CreateNodeBalancer(context.Background(), createOpts)
 	if err != nil {
 		t.Errorf("Error listing nodebalancers, expected struct, got error %v", err)
 	}

--- a/stackscripts.go
+++ b/stackscripts.go
@@ -123,7 +123,7 @@ func (c *Client) GetStackscript(ctx context.Context, id int) (*Stackscript, erro
 }
 
 // CreateStackscript creates a StackScript
-func (c *Client) CreateStackscript(ctx context.Context, createOpts *StackscriptCreateOptions) (*Stackscript, error) {
+func (c *Client) CreateStackscript(ctx context.Context, createOpts StackscriptCreateOptions) (*Stackscript, error) {
 	var body string
 	e, err := c.StackScripts.Endpoint()
 	if err != nil {

--- a/template.go
+++ b/template.go
@@ -3,6 +3,7 @@
 package linodego
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -62,12 +63,12 @@ func (v *Template) fixDates() *Template {
 }
 
 // GetTemplate gets the template with the provided ID
-func (c *Client) GetTemplate(id string) (*Template, error) {
+func (c *Client) GetTemplate(id int) (*Template, error) {
 	e, err := c.Templates.Endpoint()
 	if err != nil {
 		return nil, err
 	}
-	e = fmt.Sprintf("%s/%s", e, id)
+	e = fmt.Sprintf("%s/%d", e, id)
 	r, err := coupleAPIErrors(c.R().SetResult(&Template{}).Get(e))
 	if err != nil {
 		return nil, err
@@ -76,23 +77,22 @@ func (c *Client) GetTemplate(id string) (*Template, error) {
 }
 
 // CreateTemplate creates a Template
-func (c *Client) CreateTemplate(Template *TemplateCreateOptions) (*Template, error) {
+func (c *Client) CreateTemplate(ctx context.Context, createOpts TemplateCreateOptions) (*Template, error) {
 	var body string
 	e, err := c.Templates.Endpoint()
 	if err != nil {
 		return nil, err
 	}
 
-	req := c.R().SetResult(&Template{})
+	req := c.R(ctx).SetResult(&Template{})
 
-	if bodyData, err := json.Marshal(template); err == nil {
+	if bodyData, err := json.Marshal(createOpts); err == nil {
 		body = string(bodyData)
 	} else {
 		return nil, NewError(err)
 	}
 
 	r, err := coupleAPIErrors(req.
-		SetHeader("Content-Type", "application/json").
 		SetBody(body).
 		Post(e))
 
@@ -103,7 +103,7 @@ func (c *Client) CreateTemplate(Template *TemplateCreateOptions) (*Template, err
 }
 
 // UpdateTemplate updates the Template with the specified id
-func (c *Client) UpdateTemplate(id int, updateOpts TemplateUpdateOptions) (*Template, error) {
+func (c *Client) UpdateTemplate(ctx context.Context, id int, updateOpts TemplateUpdateOptions) (*Template, error) {
 	var body string
 	e, err := c.Templates.Endpoint()
 	if err != nil {
@@ -111,9 +111,9 @@ func (c *Client) UpdateTemplate(id int, updateOpts TemplateUpdateOptions) (*Temp
 	}
 	e = fmt.Sprintf("%s/%d", e, id)
 
-	req := c.R().SetResult(&Template{})
+	req := c.R(ctx).SetResult(&Template{})
 
-	if bodyData, err := json.Marshal(template); err == nil {
+	if bodyData, err := json.Marshal(updateOpts); err == nil {
 		body = string(bodyData)
 	} else {
 		return nil, NewError(err)
@@ -130,14 +130,14 @@ func (c *Client) UpdateTemplate(id int, updateOpts TemplateUpdateOptions) (*Temp
 }
 
 // DeleteTemplate deletes the Template with the specified id
-func (c *Client) DeleteTemplate(id int) error {
+func (c *Client) DeleteTemplate(ctx context.Context, id int) error {
 	e, err := c.Templates.Endpoint()
 	if err != nil {
 		return err
 	}
 	e = fmt.Sprintf("%s/%d", e, id)
 
-	if _, err := coupleAPIErrors(c.R().Delete(e)); err != nil {
+	if _, err := coupleAPIErrors(c.R(ctx).Delete(e)); err != nil {
 		return err
 	}
 

--- a/template.go
+++ b/template.go
@@ -2,6 +2,15 @@
 
 package linodego
 
+/*
+ - replace "Template" with "NameOfResource"
+ - replace "template" with "nameOfResource"
+ - When updating Template structs,
+   - use pointers where ever null'able would have a different meaning if the wrapper
+	 supplied "" or 0 instead
+ - Add "NameOfResource" to client.go, resources.go, pagination.go
+*/
+
 import (
 	"context"
 	"encoding/json"
@@ -15,6 +24,24 @@ type Template struct {
 	ID int
 	// UpdatedStr string `json:"updated"`
 	// Updated *time.Time `json:"-"`
+}
+
+type TemplateCreateOptions struct {
+}
+
+type TemplateUpdateOptions struct {
+}
+
+func (i Template) GetCreateOptions() (o TemplateCreateOptions) {
+	// o.Label = i.Label
+	// o.Description = copyString(o.Description)
+	return
+}
+
+func (i Template) GetUpdateOptions() (o TemplateCreateOptions) {
+	// o.Label = i.Label
+	// o.Description = copyString(o.Description)
+	return
 }
 
 // TemplatesPagedResponse represents a paginated Template API response


### PR DESCRIPTION
- Adds CreateImage, UpdateImage, DeleteImage
- Changes UpdateOptions and CreateOptions and similar Options parameters to values instead of pointers, these were never optional and the function never updated any values in the Options structures
- Changes InstanceUpdateOptions to use pointers for optional fields Backups and Alerts, adds WatchdogEnabled
- Changes InstanceClone's Disks and Configs to ints instead of strings
- Adds RescueInstance and RescueInstanceOptions
- Updates template.go which can be used as a manual template when adding support for missing endpoints

This closes #37 and addresses most of the concerns in #29 